### PR TITLE
metrics: fix use-after-free in temporal aggregation

### DIFF
--- a/src/sdk/metrics/reader.zig
+++ b/src/sdk/metrics/reader.zig
@@ -192,6 +192,49 @@ test "metric reader collects data from meter provider" {
     }
 }
 
+test "metric reader cumulative aggregation survives freeing exported measurements" {
+    // page_allocator unmaps freed pages, so the use-after-free this guards
+    // against segfaults instead of silently reading recycled bytes (which the
+    // testing allocator would do, hiding the bug). Reaching the end proves no UAF.
+    const allocator = std.heap.page_allocator;
+    const io = std.testing.io;
+
+    const mp = try MeterProvider.init(allocator, io);
+    defer mp.shutdown();
+
+    var inMem = try InMemoryExporter.init(allocator, io);
+    defer inMem.deinit();
+
+    const metric_exporter = try MetricExporter.new(allocator, io, &inMem.exporter);
+
+    var reader = try MetricReader.init(allocator, io, metric_exporter);
+    defer reader.shutdown();
+    try mp.addReader(reader);
+
+    const meter = try mp.getMeter(.{ .name = "reproduce.metrics.temporality" });
+    var counter = try meter.createCounter(u64, .{ .name = "requests" });
+
+    // Cumulative temporality: the running total must persist across collect
+    // cycles even though the caller takes ownership of and frees the exported
+    // measurements (and thus their attributes) between cycles.
+    const route: []const u8 = "/reproducer";
+    const want = [_]i64{ 1, 3 };
+    for (1..3) |round| {
+        try counter.add(@intCast(round), .{ "route", route });
+
+        try reader.collect();
+
+        const stored = try inMem.fetch(allocator);
+        defer {
+            for (stored) |*m| m.deinit(allocator);
+            allocator.free(stored);
+        }
+
+        try std.testing.expectEqual(@as(usize, 1), stored.len);
+        try std.testing.expectEqual(want[round - 1], stored[0].data.int[0].value);
+    }
+}
+
 fn deltaTemporality(_: Kind) view.Temporality {
     return .Delta;
 }

--- a/src/sdk/metrics/temporality.zig
+++ b/src/sdk/metrics/temporality.zig
@@ -73,6 +73,14 @@ pub fn init(allocator: std.mem.Allocator) !*TemporalAggregator {
 }
 
 pub fn deinit(self: *TemporalAggregator) void {
+    var int_keys = self.ints.keyIterator();
+    while (int_keys.next()) |key| {
+        if (key.datapoint_attributes) |attrs| self.memory.free(attrs);
+    }
+    var double_keys = self.doubles.keyIterator();
+    while (double_keys.next()) |key| {
+        if (key.datapoint_attributes) |attrs| self.memory.free(attrs);
+    }
     self.ints.deinit();
     self.doubles.deinit();
     self.memory.destroy(self);
@@ -104,6 +112,12 @@ fn processCumulativeDataPoints(
             gop.value_ptr.timestamps = .{ .start_time_ns = existing_start_time, .time_ns = dp_time };
             gop.value_ptr.value += dp.value;
         } else {
+            // The map outlives the measurements: their attributes are owned by the
+            // exporter and freed after export, so the key must own its own copy.
+            gop.key_ptr.datapoint_attributes = Attributes.with(dp.attributes).dupe(map.allocator) catch |err| {
+                _ = map.remove(identity);
+                return err;
+            };
             gop.value_ptr.value = dp.value;
             gop.value_ptr.timestamps = .{ .start_time_ns = dp_start_time, .time_ns = dp_time };
         }
@@ -136,6 +150,13 @@ fn processDeltaDataPoints(
             if (gop.value_ptr.timestamps) |existing_time| {
                 start_time = existing_time.time_ns;
             }
+        } else {
+            // The map outlives the measurements: their attributes are owned by the
+            // exporter and freed after export, so the key must own its own copy.
+            gop.key_ptr.datapoint_attributes = Attributes.with(dp.attributes).dupe(map.allocator) catch |err| {
+                _ = map.remove(identity);
+                return err;
+            };
         }
         dp.timestamps = .{ .start_time_ns = start_time, .time_ns = dp_time };
         // Update map with this latest datapoint


### PR DESCRIPTION
### Reason for this PR

Closes #29.

### Details

- Add a test that reproduces the page using `std.heap.page_allocator`
- Fix the bug by deep-copying datapoints' attributes in temporal aggregation