### PR TITLE
refactor: Use std Io writer for exporters

### DIFF
--- a/opentelemetry-sdk/examples/logs/basic.zig
+++ b/opentelemetry-sdk/examples/logs/basic.zig
@@ -10,7 +10,8 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a stdout exporter
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = sdk.logs.StdoutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = sdk.logs.StdoutExporter.init(&stdout_writer.interface);
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor

--- a/opentelemetry-sdk/examples/logs/batching.zig
+++ b/opentelemetry-sdk/examples/logs/batching.zig
@@ -11,7 +11,8 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a stdout exporter
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = sdk.logs.StdoutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = sdk.logs.StdoutExporter.init(&stdout_writer.interface);
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a batching processor with custom config

--- a/opentelemetry-sdk/examples/logs/std_log_basic.zig
+++ b/opentelemetry-sdk/examples/logs/std_log_basic.zig
@@ -15,7 +15,8 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a stdout exporter
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = sdk.logs.StdoutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = sdk.logs.StdoutExporter.init(&stdout_writer.interface);
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor

--- a/opentelemetry-sdk/examples/logs/std_log_migration.zig
+++ b/opentelemetry-sdk/examples/logs/std_log_migration.zig
@@ -18,7 +18,8 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a stdout exporter
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = sdk.logs.StdoutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = sdk.logs.StdoutExporter.init(&stdout_writer.interface);
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a batching processor (more realistic for production)

--- a/opentelemetry-sdk/examples/logs/std_log_per_scope.zig
+++ b/opentelemetry-sdk/examples/logs/std_log_per_scope.zig
@@ -26,7 +26,8 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a stdout exporter
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = sdk.logs.StdoutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = sdk.logs.StdoutExporter.init(&stdout_writer.interface);
     const exporter = stdout_exporter.asLogRecordExporter();
 
     // Create a simple processor

--- a/opentelemetry-sdk/examples/trace/multiple_tracers.zig
+++ b/opentelemetry-sdk/examples/trace/multiple_tracers.zig
@@ -21,7 +21,8 @@ pub fn main(init: std.process.Init) !void {
 
     // 3. Create a stdout exporter and simple processor for output
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = trace.StdOutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = trace.StdOutExporter.init(&stdout_writer.interface);
     var simple_processor = trace.SimpleProcessor.init(allocator, io, stdout_exporter.asSpanExporter());
 
     // 4. Add the processor to the provider

--- a/opentelemetry-sdk/examples/trace/simple.zig
+++ b/opentelemetry-sdk/examples/trace/simple.zig
@@ -22,7 +22,8 @@ pub fn main(init: std.process.Init) !void {
 
     // 3. Create a stdout exporter and simple processor
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = trace.StdOutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = trace.StdOutExporter.init(&stdout_writer.interface);
     var simple_processor = trace.SimpleProcessor.init(allocator, io, stdout_exporter.asSpanExporter());
 
     // 4. Add the processor to the provider

--- a/opentelemetry-sdk/src/c/logs.zig
+++ b/opentelemetry-sdk/src/c/logs.zig
@@ -359,13 +359,15 @@ pub fn loggerIsEnabled(
 /// Internal wrapper for stdout exporter that holds the exporter together.
 const StdoutLogExporterWrapper = struct {
     exporter: StdoutExporter,
+    writer: std.Io.File.Writer,
     buffer: [4096]u8,
     threaded: std.Io.Threaded,
     log_record_exporter: ?LogRecordExporter = null,
 
     fn init(self: *StdoutLogExporterWrapper) void {
         // Initialize the exporter with stdout
-        self.exporter = StdoutExporter.init(std.Io.File.stdout().writer(self.threaded.io(), &self.buffer));
+        self.writer = std.Io.File.stdout().writer(self.threaded.io(), &self.buffer);
+        self.exporter = StdoutExporter.init(&self.writer.interface);
         // Now create the log record exporter interface
         self.log_record_exporter = self.exporter.asLogRecordExporter();
     }
@@ -395,6 +397,7 @@ pub fn logRecordExporterStdoutCreate() callconv(.c) ?*OtelLogRecordExporter {
     wrapper.* = .{
         .buffer = undefined,
         .threaded = std.Io.Threaded.init(allocator, .{}),
+        .writer = undefined,
         .exporter = undefined,
         .log_record_exporter = null,
     };

--- a/opentelemetry-sdk/src/c/trace.zig
+++ b/opentelemetry-sdk/src/c/trace.zig
@@ -679,6 +679,7 @@ pub fn spanGetSpanIdHex(
 /// Internal wrapper for stdout exporter that holds the exporter together.
 const StdoutExporterWrapper = struct {
     exporter: StdoutExporter,
+    writer: std.Io.File.Writer,
     buffer: [4096]u8,
     threaded: std.Io.Threaded,
 };
@@ -706,9 +707,11 @@ pub fn spanExporterStdoutCreate() callconv(.c) ?*OtelSpanExporter {
     wrapper.* = .{
         .buffer = undefined,
         .threaded = std.Io.Threaded.init(allocator, .{}),
+        .writer = undefined,
         .exporter = undefined,
     };
-    wrapper.exporter = StdoutExporter.init(std.Io.File.stdout().writer(wrapper.threaded.io(), &wrapper.buffer));
+    wrapper.writer = std.Io.File.stdout().writer(wrapper.threaded.io(), &wrapper.buffer);
+    wrapper.exporter = StdoutExporter.init(&wrapper.writer.interface);
 
     const handle = allocator.create(SpanExporterHandle) catch {
         wrapper.threaded.deinit();

--- a/opentelemetry-sdk/src/sdk/logs/exporters/generic.zig
+++ b/opentelemetry-sdk/src/sdk/logs/exporters/generic.zig
@@ -29,75 +29,62 @@ const SerializableLogRecord = struct {
     }
 };
 
-/// GenericWriterExporter is the generic LogRecordExporter that outputs log records to the given writer.
-fn GenericWriterExporter(
-    comptime Writer: type,
-) type {
-    return struct {
-        writer: Writer,
+/// WriterExporter outputs log records to the given writer.
+const WriterExporter = struct {
+    writer: *std.Io.Writer,
 
-        const Self = @This();
+    const Self = @This();
 
-        pub fn init(writer: Writer) Self {
-            return Self{
-                .writer = writer,
-            };
+    /// The writer must remain valid for the lifetime of the exporter.
+    pub fn init(writer: *std.Io.Writer) Self {
+        return Self{
+            .writer = writer,
+        };
+    }
+
+    pub fn exportLogs(ctx: *anyopaque, log_records: []logs.ReadableLogRecord) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        // Convert log records to serializable format
+        var serializable_logs: std.ArrayList(SerializableLogRecord) = .empty;
+        defer serializable_logs.deinit(std.heap.page_allocator);
+
+        for (log_records) |log_record| {
+            try serializable_logs.append(std.heap.page_allocator, SerializableLogRecord.fromLogRecord(log_record));
         }
 
-        fn writerInterface(self: *Self) *std.Io.Writer {
-            if (@hasField(Writer, "interface")) {
-                return &self.writer.interface;
-            }
-            if (@hasField(Writer, "writer")) {
-                return &self.writer.writer;
-            }
-            return &self.writer;
-        }
+        // Serialize to JSON - format directly to this writer
+        try self.writer.print("{f}", .{std.json.fmt(serializable_logs.items, .{})});
+        try self.writer.flush();
+    }
 
-        pub fn exportLogs(ctx: *anyopaque, log_records: []logs.ReadableLogRecord) anyerror!void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+    pub fn shutdown(_: *anyopaque) anyerror!void {}
 
-            // Convert log records to serializable format
-            var serializable_logs: std.ArrayList(SerializableLogRecord) = .empty;
-            defer serializable_logs.deinit(std.heap.page_allocator);
-
-            for (log_records) |log_record| {
-                try serializable_logs.append(std.heap.page_allocator, SerializableLogRecord.fromLogRecord(log_record));
-            }
-
-            // Serialize to JSON - format directly to this writer
-            const writer = self.writerInterface();
-            try writer.print("{f}", .{std.json.fmt(serializable_logs.items, .{})});
-            try writer.flush();
-        }
-
-        pub fn shutdown(_: *anyopaque) anyerror!void {}
-
-        pub fn asLogRecordExporter(self: *Self) LogRecordExporter {
-            return .{
-                .ptr = self,
-                .vtable = &.{
-                    .exportLogsFn = exportLogs,
-                    .shutdownFn = shutdown,
-                },
-            };
-        }
-    };
-}
+    pub fn asLogRecordExporter(self: *Self) LogRecordExporter {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .exportLogsFn = exportLogs,
+                .shutdownFn = shutdown,
+            },
+        };
+    }
+};
 
 /// StdoutExporter outputs log records into OS stdout.
 /// ref: https://opentelemetry.io/docs/specs/otel/logs/sdk_exporters/stdout/
-pub const StdoutExporter = GenericWriterExporter(std.Io.File.Writer);
+pub const StdoutExporter = WriterExporter;
 
 /// InMemoryExporter exports log records to in-memory buffer.
-/// It is designed for testing GenericWriterExporter.
-pub const InMemoryExporter = GenericWriterExporter(std.Io.Writer.Allocating);
+/// It is designed for testing WriterExporter.
+pub const InMemoryExporter = WriterExporter;
 
-test "GenericWriterExporter" {
+test "WriterExporter" {
     var out_buf: std.ArrayList(u8) = .empty;
     {
-        var inmemory_exporter = InMemoryExporter.init(.fromArrayList(std.testing.allocator, &out_buf));
-        errdefer inmemory_exporter.writer.deinit();
+        var writer = std.Io.Writer.Allocating.fromArrayList(std.testing.allocator, &out_buf);
+        var inmemory_exporter = InMemoryExporter.init(&writer.writer);
+        errdefer writer.deinit();
         var exporter = inmemory_exporter.asLogRecordExporter();
 
         // Create a test log record
@@ -116,7 +103,7 @@ test "GenericWriterExporter" {
         var log_records = [_]logs.ReadableLogRecord{readable};
         try exporter.exportLogs(log_records[0..log_records.len]);
 
-        out_buf = inmemory_exporter.writer.toArrayList();
+        out_buf = writer.toArrayList();
     }
     defer out_buf.deinit(std.testing.allocator);
 

--- a/opentelemetry-sdk/src/sdk/logs/std_log_bridge.zig
+++ b/opentelemetry-sdk/src/sdk/logs/std_log_bridge.zig
@@ -324,8 +324,9 @@ test "std_log_bridge logFn prints text for body" {
 
     var buf = try std.ArrayList(u8).initCapacity(std.testing.allocator, 1024);
     {
-        var in_mem: InMemoryExporter = .init(.fromArrayList(std.testing.allocator, &buf));
-        errdefer in_mem.writer.deinit();
+        var writer = std.Io.Writer.Allocating.fromArrayList(std.testing.allocator, &buf);
+        var in_mem: InMemoryExporter = .init(&writer.writer);
+        errdefer writer.deinit();
         const exporter = in_mem.asLogRecordExporter();
 
         var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io2, exporter);
@@ -342,7 +343,7 @@ test "std_log_bridge logFn prints text for body" {
 
         logFn(std.log.Level.debug, .test_scope, "test text", .{});
 
-        buf = in_mem.writer.toArrayList();
+        buf = writer.toArrayList();
     }
     defer buf.deinit(std.testing.allocator);
 

--- a/opentelemetry-sdk/src/sdk/trace/exporters/generic.zig
+++ b/opentelemetry-sdk/src/sdk/trace/exporters/generic.zig
@@ -34,77 +34,62 @@ const SerializableSpan = struct {
     }
 };
 
-/// GenericWriterExporter is the generic SpanExporter that outputs spans to the given writer.
-fn GenericWriterExporter(
-    comptime Writer: type,
-) type {
-    return struct {
-        writer: Writer,
+/// WriterExporter outputs spans to the given writer.
+const WriterExporter = struct {
+    writer: *std.Io.Writer,
 
-        const Self = @This();
+    const Self = @This();
 
-        pub fn init(writer: Writer) Self {
-            return Self{
-                .writer = writer,
-            };
+    /// The writer must remain valid for the lifetime of the exporter.
+    pub fn init(writer: *std.Io.Writer) Self {
+        return Self{
+            .writer = writer,
+        };
+    }
+
+    pub fn exportSpans(ctx: *anyopaque, spans: []trace.Span) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        // Convert spans to serializable format
+        var serializable_spans = std.ArrayList(SerializableSpan).empty;
+        defer serializable_spans.deinit(std.heap.page_allocator);
+
+        for (spans) |span| {
+            try serializable_spans.append(std.heap.page_allocator, SerializableSpan.fromSpan(span));
         }
 
-        fn writerInterface(self: *Self) *std.Io.Writer {
-            if (@hasField(Writer, "interface")) {
-                return &self.writer.interface;
-            }
-            if (@hasField(Writer, "writer")) {
-                return &self.writer.writer;
-            }
-            return &self.writer;
-        }
+        try self.writer.print("{f}", .{std.json.fmt(serializable_spans.items, .{})});
+        try self.writer.flush();
+    }
 
-        pub fn exportSpans(ctx: *anyopaque, spans: []trace.Span) anyerror!void {
-            const self: *Self = @ptrCast(@alignCast(ctx));
+    pub fn shutdown(_: *anyopaque) anyerror!void {}
 
-            // Convert spans to serializable format
-            var serializable_spans = std.ArrayList(SerializableSpan).empty;
-            defer serializable_spans.deinit(std.heap.page_allocator);
-
-            for (spans) |span| {
-                try serializable_spans.append(std.heap.page_allocator, SerializableSpan.fromSpan(span));
-            }
-
-            const writer = self.writerInterface();
-            try writer.print("{f}", .{std.json.fmt(serializable_spans.items, .{})});
-            try writer.flush();
-        }
-
-        pub fn shutdown(_: *anyopaque) anyerror!void {}
-
-        pub fn asSpanExporter(self: *Self) SpanExporter {
-            return .{
-                .ptr = self,
-                .vtable = &.{
-                    .exportSpansFn = exportSpans,
-                    .shutdownFn = shutdown,
-                },
-            };
-        }
-    };
-}
+    pub fn asSpanExporter(self: *Self) SpanExporter {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .exportSpansFn = exportSpans,
+                .shutdownFn = shutdown,
+            },
+        };
+    }
+};
 
 /// StdoutExporter outputs spans into OS stdout.
 /// ref: https://opentelemetry.io/docs/specs/otel/trace/sdk_exporters/stdout/
-pub const StdoutExporter = GenericWriterExporter(std.Io.File.Writer);
+pub const StdoutExporter = WriterExporter;
 
 /// InmemoryExporter exports spans to in-memory buffer.
-/// it is designed for testing GenericWriterExporter.
-pub const InMemoryExporter = GenericWriterExporter(std.Io.Writer.Allocating);
+/// it is designed for testing WriterExporter.
+pub const InMemoryExporter = WriterExporter;
 
-// Example showing how to use GenericWriterExporter to create a custom exporter.
-// This demonstrates the pattern used by both StdoutExporter and InMemoryExporter.
-test "exporters/trace GenericWriterExporter" {
+// Example showing how to use WriterExporter with an arbitrary writer.
+test "exporters/trace WriterExporter" {
     var out_buf = std.ArrayList(u8).empty;
     {
-        // Create a custom exporter using the generic type
-        var inmemory_exporter = InMemoryExporter.init(.fromArrayList(std.testing.allocator, &out_buf));
-        errdefer inmemory_exporter.writer.deinit();
+        var writer = std.Io.Writer.Allocating.fromArrayList(std.testing.allocator, &out_buf);
+        var inmemory_exporter = InMemoryExporter.init(&writer.writer);
+        errdefer writer.deinit();
         var exporter = inmemory_exporter.asSpanExporter();
 
         // Create a test span
@@ -122,7 +107,7 @@ test "exporters/trace GenericWriterExporter" {
         var spans = [_]trace.Span{test_span};
         try exporter.exportSpans(spans[0..spans.len]);
 
-        out_buf = inmemory_exporter.writer.toArrayList();
+        out_buf = writer.toArrayList();
     }
     defer out_buf.deinit(std.testing.allocator);
 
@@ -135,7 +120,8 @@ test StdoutExporter {
     // and can be instantiated correctly
     const io = std.testing.io;
     var stdout_buffer: [4096]u8 = undefined;
-    var stdout_exporter = StdoutExporter.init(std.Io.File.stdout().writer(io, &stdout_buffer));
+    var writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    var stdout_exporter = StdoutExporter.init(&writer.interface);
     var exporter = stdout_exporter.asSpanExporter();
 
     // Create a test span to verify export works
@@ -158,8 +144,9 @@ test StdoutExporter {
 test InMemoryExporter {
     var out_buf = std.ArrayList(u8).empty;
     {
-        var inmemory_exporter = InMemoryExporter.init(.fromArrayList(std.testing.allocator, &out_buf));
-        errdefer inmemory_exporter.writer.deinit();
+        var writer = std.Io.Writer.Allocating.fromArrayList(std.testing.allocator, &out_buf);
+        var inmemory_exporter = InMemoryExporter.init(&writer.writer);
+        errdefer writer.deinit();
         var exporter = inmemory_exporter.asSpanExporter();
 
         // Create test spans with different properties
@@ -186,7 +173,7 @@ test InMemoryExporter {
         try exporter.exportSpans(spans[0..spans.len]);
         try exporter.shutdown();
 
-        out_buf = inmemory_exporter.writer.toArrayList();
+        out_buf = writer.toArrayList();
     }
     defer out_buf.deinit(std.testing.allocator);
 


### PR DESCRIPTION
Fixes #30.

Replace the log and trace `GenericWriterExporter` compile-time generic with a concrete exporter that accepts `*std.Io.Writer`. This removes runtime field inspection for concrete writer layouts while preserving the existing stdout and in-memory exporter names.

The C wrappers, tests, and examples now retain their concrete writers for the exporter lifetime and pass the standard writer interface explicitly.

Validation:
- `zig build`
- `zig build test` (289 tests passed)
- `zig build examples`
- `zig fmt --check` on all changed Zig files
- `git diff --check`