### PR TITLE
build(proto): remove submodule and use lazyDep

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,28 @@ jobs:
           mirror: 'https://zigmirror.com'
       - run: zig fmt --check .
 
+  # Validate the opentelemetry-proto module: the SDK depends on it, so this runs
+  # before the SDK jobs (see `needs: proto`).
+  proto:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: ${{ env.ZIG_VERSION }}
+          mirror: 'https://zigmirror.com'
+      - run: zig build --fetch
+      # Regenerate the vendored bindings from the pinned proto sources (protoc is
+      # provided by the protobuf dependency) and fail if they drift from git.
+      - name: Regenerate proto bindings
+        run: |
+          zig build proto-generate
+          git diff --exit-code opentelemetry-proto/src
+      - name: Run proto module tests
+        run: zig build proto-test
+
   run_test:
+    needs: proto
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,6 +58,7 @@ jobs:
         timeout-minutes: 3
 
   build_examples:
+    needs: proto
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,6 +71,7 @@ jobs:
 
   # Execute bencharmks only if the PR has a specific label 'run::benchmarks'
   benchmarks:
+    needs: proto
     if: contains(github.event.pull_request.labels.*.name, 'run::benchmarks')
     runs-on: ubuntu-latest
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "opentelemetry-proto/proto-src"]
-	path = opentelemetry-proto/proto-src
-	url = https://github.com/open-telemetry/opentelemetry-proto.git
-	branch = main

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,6 +33,14 @@
             .url = "git+https://github.com/Arwalk/zig-protobuf?ref=v5.0.0#1f6cb06156b3ff4f52f98bc14f829c0b8393a6fc",
             .hash = "protobuf-5.0.0-0e82avKUKAAVwTWJzTIEZ14Fu0zC11_lElR8tE6H__y1",
         },
+        // Upstream .proto definitions, used only to regenerate the vendored
+        // bindings (zig build proto-generate -Dproto-src). Lazy so plain builds
+        // and consumers never fetch it. Re-pin with `zig build proto-update-tag`.
+        .opentelemetry_proto = .{
+            .url = "git+https://github.com/open-telemetry/opentelemetry-proto?ref=v1.11.0#790608c4d51e6ffc12210b541e8514cbed9e91a4",
+            .hash = "N-V-__8AAIOkBQAVntdoElRMXVcOsnc-qJUZDDT8auh8Z3aj",
+            .lazy = true,
+        },
     },
     .paths = .{
         "build.zig",

--- a/build/proto/build.zig
+++ b/build/proto/build.zig
@@ -6,11 +6,11 @@ const BuildError = helpers.BuildError;
 const BuildModules = helpers.BuildModules;
 const CompilationInfo = helpers.CompilationInfo;
 
-// Path of the vendored OpenTelemetry proto source root relative to build.zig.
+// Path of the vendored opentelemetry-proto module (generated bindings) relative to build.zig.
 const proto_root = "opentelemetry-proto";
 
 // OpenTelemetry proto definitions to generate Zig bindings from, relative to
-// the proto-src submodule root. Add entries here as the API grows.
+// the opentelemetry_proto dependency root. Add entries here as the API grows.
 const proto_files = [_][]const u8{
     // Signals
     "opentelemetry/proto/common/v1/common.proto",
@@ -52,58 +52,53 @@ pub fn Setup(
 }
 
 // Registers the "proto-generate" step, regenerating the Zig bindings under
-// src/ from the proto-src submodule using protoc. Run it after updating
-// the submodule (see the "update-tag" step).
+// src/ with protoc from the pinned opentelemetry_proto sources. Those sources
+// are a lazy dependency (see build.zig.zon): Zig fetches them on demand the
+// first time this step is configured. Bump the pin with "proto-update-tag".
 fn addGenerateStep(b: *std.Build, info: CompilationInfo) !void {
+    const step = b.step("proto-generate", "Regenerate proto bindings from the opentelemetry_proto sources (requires protoc)");
+
+    // Null on the first pass: Zig fetches the lazy dep and re-runs the build.
+    const proto_dep = b.lazyDependency("opentelemetry_proto", .{}) orelse return;
+
+    var source_files: [proto_files.len]std.Build.LazyPath = undefined;
+    for (&source_files, proto_files) |*src, rel| {
+        src.* = proto_dep.path(rel);
+    }
+
     // protoc code generation is driven by the protobuf dependency's builder.
     const protobuf_dep = b.dependency("protobuf", .{
         .target = info.target,
         .optimize = info.optimize,
     });
-
-    var source_files: [proto_files.len]std.Build.LazyPath = undefined;
-    for (&source_files, proto_files) |*src, rel| {
-        src.* = b.path(b.pathJoin(&.{ proto_root, "proto-src", rel }));
-    }
-
     const protoc_step = protobuf.RunProtocStep.create(protobuf_dep.builder, info.target, .{
         .destination_directory = b.path(proto_root ++ "/src"),
         .source_files = &source_files,
         .include_directories = &.{
-            // Imports in proto files resolve against the submodule root.
-            b.path(proto_root ++ "/proto-src"),
+            // Imports in proto files resolve against the dependency root.
+            proto_dep.path("."),
         },
     });
     protoc_step.verbose = info.optimize == .Debug;
 
-    const step = b.step("proto-generate", "Regenerate proto bindings from the proto-src submodule (requires protoc)");
     step.dependOn(&protoc_step.step);
 }
 
-// Registers the "update-tag" step, moving the proto-src submodule (the official
-// OpenTelemetry proto definitions) to a given tag, or the latest commit on its
-// tracked branch. Regenerate the bindings from the updated submodule afterwards.
+// Registers the "proto-update-tag" step, re-pinning the opentelemetry_proto
+// dependency in build.zig.zon to a given tag (or the tracked branch, main).
+// It shells out to `zig fetch --save`, which rewrites the url and hash.
+// Regenerate the bindings from the updated pin afterwards (proto-generate).
 fn addUpdateTagStep(b: *std.Build) *std.Build.Step {
     const tag = b.option([]const u8, "tag",
-        \\Tag of the OpenTelemetry proto submodule to check out.
-        \\If not set, the latest commit on the tracked branch (main) is used.
-    );
+        \\Tag or ref of the OpenTelemetry proto repo to pin in build.zig.zon.
+        \\If not set, the tracked branch (main) is used.
+    ) orelse "main";
 
-    // Pull the latest commit on the submodule's tracked branch.
-    const update_remote = b.addSystemCommand(&.{ "git", "submodule", "update", "--remote" });
+    const url = b.fmt("git+https://github.com/open-telemetry/opentelemetry-proto#{s}", .{tag});
+    const fetch = b.addSystemCommand(&.{ b.graph.zig_exe, "fetch", "--save=opentelemetry_proto", url });
 
-    const update_step = b.step("proto-update-tag", "Update the OpenTelemetry proto submodule to -Dtag (or latest)");
-
-    if (tag) |t| {
-        const update_to_tag = b.addSystemCommand(&.{
-            "git",                           "submodule", "foreach",
-            b.fmt("git checkout {s}", .{t}),
-        });
-        update_to_tag.step.dependOn(&update_remote.step);
-        update_step.dependOn(&update_to_tag.step);
-    } else {
-        update_step.dependOn(&update_remote.step);
-    }
+    const update_step = b.step("proto-update-tag", "Re-pin the opentelemetry_proto dependency in build.zig.zon to -Dtag (or main)");
+    update_step.dependOn(&fetch.step);
 
     return update_step;
 }

--- a/opentelemetry-proto/README.md
+++ b/opentelemetry-proto/README.md
@@ -33,26 +33,23 @@ const trace = proto.trace_v1;
 
 ### Regenerating the bindings
 
-The `.proto` definitions live in the `proto-src` git submodule, which tracks the
-`main` branch of the official
+The upstream `.proto` definitions are a lazy dependency (`opentelemetry_proto`
+in `build.zig.zon`), pinned to a release of the official
 [open-telemetry/opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto)
-repository. After cloning, initialize it:
-
-```bash
-git submodule update --init opentelemetry-proto/proto-src
-```
+repository. Being lazy, it is only fetched when regenerating, never during a
+plain build or by consumers of the package.
 
 To regenerate the bindings against a newer OpenTelemetry proto release (run from
 the repo root; requires `protoc`):
 
 ```bash
-# Move the submodule to a specific tag (or omit -Dtag for the latest main).
+# Re-pin build.zig.zon to a tag (or omit -Dtag for the tracked branch, main).
 zig build proto-update-tag -Dtag=vX.Y.Z
-# Regenerate src/*.pb.zig from the submodule.
+# Fetch the pinned sources (on demand) and regenerate src/*.pb.zig.
 zig build proto-generate
 ```
 
-Commit both the submodule bump and the regenerated `src/`.
+Commit both the `build.zig.zon` bump and the regenerated `src/`.
 
 ### Dependencies
 


### PR DESCRIPTION
### Reason for this PR

Follow up of #47.

### Details

Remove the submodule used to checkout the `opentelemetry-proto` repository.
It is now cloned as a lazy dependency by the Zig build system and read from the cache as a dependency when needed (by the `opentelemetry-proto` package).