### PR TITLE
trace: end example spans through Tracer.endSpan

### DIFF
--- a/opentelemetry-sdk/examples/trace/multiple_tracers.zig
+++ b/opentelemetry-sdk/examples/trace/multiple_tracers.zig
@@ -100,8 +100,8 @@ pub fn main(init: std.process.Init) !void {
     try payment_span.addEvent("Payment authorized", null, null);
     try db_span.addEvent("Query executed successfully", null, null);
 
-    // End spans - use span.end() for basic functionality
-    user_span.end(null);
-    payment_span.end(null);
-    db_span.end(null);
+    // End spans - use tracer.endSpan() for basic functionality
+    user_tracer.endSpan(&user_span);
+    payment_tracer.endSpan(&payment_span);
+    database_tracer.endSpan(&db_span);
 }

--- a/opentelemetry-sdk/examples/trace/simple.zig
+++ b/opentelemetry-sdk/examples/trace/simple.zig
@@ -94,12 +94,12 @@ pub fn main(init: std.process.Init) !void {
     clock.sleep(50 * std.time.ns_per_ms); // DB query time
 
     // End the DB span first (child spans should end before parent)
-    db_span.end(null);
+    db_tracer.endSpan(&db_span);
 
     clock.sleep(50 * std.time.ns_per_ms); // HTTP processing time
 
     // End the HTTP span
-    http_span.end(null);
+    http_tracer.endSpan(&http_span);
 
     // Verify spans were created successfully with valid IDs (not all zeros)
     const zero_trace_id = [_]u8{0} ** 16;

--- a/opentelemetry-sdk/src/api/trace/span.zig
+++ b/opentelemetry-sdk/src/api/trace/span.zig
@@ -389,6 +389,8 @@ pub const Span = struct {
     }
 
     /// End the Span
+    /// NOTE: This does not notify span processors. Use Tracer.endSpan to end a
+    /// span through the SDK; calling this first makes that call a no-op.
     pub fn end(self: *Self, timestamp: ?u64) void {
         if (!self.is_recording) return;
 


### PR DESCRIPTION
Part of #57 (the short-term item; making `Span.end` notify processors itself is left open there).

`Span.end()` only records the end timestamp and clears `is_recording`; it does not notify span processors. Both trace examples wire up a `SimpleProcessor` and a `StdOutExporter` but ended their spans with `span.end(null)`, so no span ever reached the processor and the examples printed nothing.

This change:

- switches both trace examples to end each span through its owning tracer's `endSpan`;
- adds a NOTE on `Span.end` that it does not notify processors, and that calling it before `Tracer.endSpan` makes that call a no-op.

No SDK behavior changes: the `span.zig` edit is a doc comment only.

Tests (zig 0.16.0, macOS aarch64):

- `zig build sdk-examples -Dexamples-filter=simple`: printed nothing before, prints the two spans' JSON after
- `zig build sdk-examples -Dexamples-filter=multiple_tracers`: printed nothing before, prints the three spans' JSON after
- `zig build sdk-test`: 289 tests passed
- `zig fmt --check` on the three touched files
