### PR TITLE
fix: export parent span identifiers

### DIFF
--- a/opentelemetry-sdk/src/api/trace/span.zig
+++ b/opentelemetry-sdk/src/api/trace/span.zig
@@ -168,6 +168,7 @@ pub const TraceState = struct {
 /// Span represents a single operation within a trace.
 pub const Span = struct {
     span_context: SpanContext,
+    parent_span_id: ?trace.SpanID,
     name: []const u8,
     kind: SpanKind,
     start_time_unix_nano: u64,
@@ -225,6 +226,7 @@ pub const Span = struct {
     pub fn init(allocator: std.mem.Allocator, span_context: SpanContext, name: []const u8, kind: SpanKind, scope: InstrumentationScope) Self {
         return Self{
             .span_context = span_context,
+            .parent_span_id = null,
             .name = name,
             .kind = kind,
             .start_time_unix_nano = @as(u64, @intCast(clock.nanoTimestamp())),
@@ -246,6 +248,7 @@ pub const Span = struct {
         var dummy_allocator = std.heap.FixedBufferAllocator.init(&[_]u8{});
         return Self{
             .span_context = span_context,
+            .parent_span_id = null,
             .name = "", // Non-recording spans don't have meaningful names
             .kind = .Internal,
             .start_time_unix_nano = 0,

--- a/opentelemetry-sdk/src/sdk/trace/exporters/generic.zig
+++ b/opentelemetry-sdk/src/sdk/trace/exporters/generic.zig
@@ -9,6 +9,7 @@ const InstrumentationScope = @import("../../../scope.zig").InstrumentationScope;
 const SerializableSpan = struct {
     trace_id: [16]u8,
     span_id: [8]u8,
+    parent_span_id: ?[8]u8,
     name: []const u8,
     kind: trace.SpanKind,
     start_time_unix_nano: u64,
@@ -22,6 +23,7 @@ const SerializableSpan = struct {
         return SerializableSpan{
             .trace_id = span.span_context.trace_id.value,
             .span_id = span.span_context.span_id.value,
+            .parent_span_id = if (span.parent_span_id) |parent_span_id| parent_span_id.value else null,
             .name = span.name,
             .kind = span.kind,
             .start_time_unix_nano = span.start_time_unix_nano,
@@ -142,6 +144,7 @@ test StdoutExporter {
 }
 
 test InMemoryExporter {
+    const expected_parent_span_id = [8]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
     var out_buf = std.ArrayList(u8).empty;
     {
         var writer = std.Io.Writer.Allocating.fromArrayList(std.testing.allocator, &out_buf);
@@ -151,7 +154,7 @@ test InMemoryExporter {
 
         // Create test spans with different properties
         const trace_id = trace.TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
-        const span_id_1 = trace.SpanID.init([8]u8{ 1, 2, 3, 4, 5, 6, 7, 8 });
+        const span_id_1 = trace.SpanID.init(expected_parent_span_id);
         const span_id_2 = trace.SpanID.init([8]u8{ 8, 7, 6, 5, 4, 3, 2, 1 });
         var trace_state = trace.TraceState.init(std.testing.allocator);
         defer trace_state.deinit();
@@ -166,6 +169,7 @@ test InMemoryExporter {
         // Second span - Client kind
         const span_context_2 = trace.SpanContext.init(trace_id, span_id_2, trace.TraceFlags.default(), trace_state, false);
         var span_2 = trace.Span.init(std.testing.allocator, span_context_2, "span-client", .Client, scope);
+        span_2.parent_span_id = span_id_1;
         defer span_2.deinit();
 
         // Export spans
@@ -185,4 +189,12 @@ test InMemoryExporter {
     try std.testing.expect(std.mem.indexOf(u8, out_buf.items, "Client") != null);
     try std.testing.expect(std.mem.indexOf(u8, out_buf.items, "trace_id") != null);
     try std.testing.expect(std.mem.indexOf(u8, out_buf.items, "span_id") != null);
+
+    const ExportedParent = struct { parent_span_id: ?[]const u8 };
+    const parsed = try std.json.parseFromSlice([]ExportedParent, std.testing.allocator, out_buf.items, .{
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value[0].parent_span_id == null);
+    try std.testing.expectEqualSlices(u8, &expected_parent_span_id, parsed.value[1].parent_span_id.?);
 }

--- a/opentelemetry-sdk/src/sdk/trace/exporters/otlp.zig
+++ b/opentelemetry-sdk/src/sdk/trace/exporters/otlp.zig
@@ -180,6 +180,7 @@ pub const OTLPExporter = struct {
                 for (scope_span.spans.items) |*span| {
                     self.allocator.free(span.trace_id);
                     self.allocator.free(span.span_id);
+                    if (span.parent_span_id.len > 0) self.allocator.free(span.parent_span_id);
                     span.attributes.deinit(self.allocator);
 
                     for (span.events.items) |*event| {
@@ -261,11 +262,16 @@ pub const OTLPExporter = struct {
 
         const trace_id = span_context.trace_id.toBinary();
         const span_id = span_context.span_id.toBinary();
+        const parent_span_id: []const u8 = if (span.parent_span_id) |id| parent: {
+            const binary = id.toBinary();
+            break :parent try allocator.dupe(u8, &binary);
+        } else "";
+        errdefer if (parent_span_id.len > 0) allocator.free(parent_span_id);
         return pbtrace.Span{
             .trace_id = try allocator.dupe(u8, &trace_id),
             .span_id = try allocator.dupe(u8, &span_id),
             .trace_state = (""), // Convert trace state if needed
-            .parent_span_id = (""), // TODO: get from parent context
+            .parent_span_id = parent_span_id,
             .flags = @intCast(span_context.trace_flags.value),
             .name = (span.name),
             .kind = switch (span.kind) {
@@ -424,6 +430,40 @@ test "span trace_id and span_id survive stack reuse" {
     const otlp_span = request.resource_spans.items[0].scope_spans.items[0].spans.items[0];
     try std.testing.expectEqualSlices(u8, &expected_trace_id, otlp_span.trace_id);
     try std.testing.expectEqualSlices(u8, &expected_span_id, otlp_span.span_id);
+}
+
+test "span parent_span_id is exported" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const expected_parent_span_id = [8]u8{ 21, 22, 23, 24, 25, 26, 27, 28 };
+
+    var env_map = std.process.Environ.Map.init(allocator);
+    defer env_map.deinit();
+    var config = try otlp.ConfigOptions.init(allocator, &env_map);
+    defer config.deinit();
+
+    var exporter = try OTLPExporter.init(allocator, io, config);
+    defer exporter.deinit();
+
+    var trace_state = trace.TraceState.init(allocator);
+    defer trace_state.deinit();
+    const span_context = trace.SpanContext.init(
+        trace.TraceID.init([16]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }),
+        trace.SpanID.init([8]u8{ 11, 12, 13, 14, 15, 16, 17, 18 }),
+        trace.TraceFlags.default(),
+        trace_state,
+        false,
+    );
+    var test_span = trace.Span.init(allocator, span_context, "child", .Internal, .{ .name = "test" });
+    defer test_span.deinit();
+    test_span.parent_span_id = trace.SpanID.init(expected_parent_span_id);
+
+    var spans = [_]trace.Span{test_span};
+    var request = try exporter.spansToOTLPRequest(spans[0..]);
+    defer exporter.cleanupRequest(&request);
+
+    const otlp_span = request.resource_spans.items[0].scope_spans.items[0].spans.items[0];
+    try std.testing.expectEqualSlices(u8, &expected_parent_span_id, otlp_span.parent_span_id);
 }
 
 test "OTLPExporter basic functionality" {

--- a/opentelemetry-sdk/src/sdk/trace/provider.zig
+++ b/opentelemetry-sdk/src/sdk/trace/provider.zig
@@ -320,10 +320,10 @@ pub const Tracer = struct {
 
         // Create the span with instrumentation scope
         var span = trace_api.Span.init(allocator, span_context, span_name, options.kind, self.scope);
-        span.parent_span_id = if (parent_span_context) |parent_sc| 
-          (if (parent_sc.span_id.isValid()) parent_sc.span_id else null) 
+        span.parent_span_id = if (parent_span_context) |parent_sc|
+            (if (parent_sc.span_id.isValid()) parent_sc.span_id else null)
         else
-          null;
+            null;
         span.is_recording = true; // SDK spans are recording by default
 
         // Set attributes if provided

--- a/opentelemetry-sdk/src/sdk/trace/provider.zig
+++ b/opentelemetry-sdk/src/sdk/trace/provider.zig
@@ -320,6 +320,7 @@ pub const Tracer = struct {
 
         // Create the span with instrumentation scope
         var span = trace_api.Span.init(allocator, span_context, span_name, options.kind, self.scope);
+        span.parent_span_id = if (parent_span_context) |parent_sc| parent_sc.span_id else null;
         span.is_recording = true; // SDK spans are recording by default
 
         // Set attributes if provided
@@ -390,6 +391,34 @@ test "TracerProvider basic functionality" {
 
     try std.testing.expectEqualStrings("test-span", span.name);
     try std.testing.expect(span.is_recording);
+}
+
+test "Tracer records parent span ID" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var default_prng = std.Random.DefaultPrng.init(0);
+    const random_generator = RandomIDGenerator.init(default_prng.random());
+
+    var provider = try TracerProvider.init(allocator, io, IDGenerator{ .Random = random_generator });
+    defer provider.shutdown();
+
+    const tracer = try provider.getTracer(.{ .name = "test-tracer", .version = "1.0.0" });
+    var parent = try tracer.startSpan(allocator, "parent", .{});
+    defer parent.deinit();
+    try std.testing.expect(parent.parent_span_id == null);
+
+    var parent_context = try trace_api.serializeSpanContext(allocator, parent.span_context);
+    defer {
+        trace_api.freeSerializedSpanContext(allocator, parent_context);
+        parent_context.deinit();
+    }
+
+    var child = try tracer.startSpan(allocator, "child", .{ .parent_context = parent_context });
+    defer child.deinit();
+
+    try std.testing.expectEqual(parent.span_context.trace_id.value, child.span_context.trace_id.value);
+    try std.testing.expectEqual(parent.span_context.span_id.value, child.parent_span_id.?.value);
 }
 
 // Mock processor

--- a/opentelemetry-sdk/src/sdk/trace/provider.zig
+++ b/opentelemetry-sdk/src/sdk/trace/provider.zig
@@ -320,7 +320,10 @@ pub const Tracer = struct {
 
         // Create the span with instrumentation scope
         var span = trace_api.Span.init(allocator, span_context, span_name, options.kind, self.scope);
-        span.parent_span_id = if (parent_span_context) |parent_sc| parent_sc.span_id else null;
+        span.parent_span_id = if (parent_span_context) |parent_sc| 
+          (if (parent_sc.span_id.isValid()) parent_sc.span_id else null) 
+        else
+          null;
         span.is_recording = true; // SDK spans are recording by default
 
         // Set attributes if provided

--- a/opentelemetry-sdk/src/sdk/trace/span_processor.zig
+++ b/opentelemetry-sdk/src/sdk/trace/span_processor.zig
@@ -378,6 +378,7 @@ pub const BatchingProcessor = struct {
 
         result.start_time_unix_nano = span.start_time_unix_nano;
         result.end_time_unix_nano = span.end_time_unix_nano;
+        result.parent_span_id = span.parent_span_id;
         result.status = span.status;
         result.is_recording = span.is_recording;
 
@@ -536,6 +537,7 @@ test "BatchingProcessor basic functionality" {
         const span_context = trace.SpanContext.init(trace_id, span_id, trace.TraceFlags.default(), ts.*, false);
         const scope = InstrumentationScope{ .name = "test-lib", .version = "1.0.0" };
         span.* = trace.Span.init(allocator, span_context, "test-span", .Internal, scope);
+        span.parent_span_id = trace.SpanID.init([8]u8{ @intCast(i + 1), 9, 8, 7, 6, 5, 4, 3 });
         span.is_recording = true;
     }
     defer {
@@ -558,4 +560,7 @@ test "BatchingProcessor basic functionality" {
 
     // Verify spans were exported
     try std.testing.expectEqual(@as(usize, 3), mock_exporter.exported_spans.items.len);
+    for (mock_exporter.exported_spans.items, 0..) |span, i| {
+        try std.testing.expectEqual(@as(u8, @intCast(i + 1)), span.parent_span_id.?.value[0]);
+    }
 }


### PR DESCRIPTION
Fixes #55.

## What changed

* retain the parent span ID when a span starts from a parent context
* preserve it through the batching processor
* emit it from writer exporters and OTLP

## Validation

* `zig fmt --check opentelemetry-sdk/src/api/trace/span.zig opentelemetry-sdk/src/sdk/trace/provider.zig opentelemetry-sdk/src/sdk/trace/span_processor.zig opentelemetry-sdk/src/sdk/trace/exporters/generic.zig opentelemetry-sdk/src/sdk/trace/exporters/otlp.zig`
* `zig build sdk-test -Dtarget=x86_64-linux-musl` — 291 tests passed
* `zig build sdk-examples -Dtarget=x86_64-linux-musl`
