### PR TITLE
fix: export spans from trace examples

### DIFF
--- a/opentelemetry-sdk/examples/trace/multiple_tracers.zig
+++ b/opentelemetry-sdk/examples/trace/multiple_tracers.zig
@@ -100,8 +100,8 @@ pub fn main(init: std.process.Init) !void {
     try payment_span.addEvent("Payment authorized", null, null);
     try db_span.addEvent("Query executed successfully", null, null);
 
-    // End spans - use span.end() for basic functionality
-    user_span.end(null);
-    payment_span.end(null);
-    db_span.end(null);
+    // End spans and notify their processors
+    user_tracer.endSpan(&user_span);
+    payment_tracer.endSpan(&payment_span);
+    database_tracer.endSpan(&db_span);
 }

--- a/opentelemetry-sdk/examples/trace/simple.zig
+++ b/opentelemetry-sdk/examples/trace/simple.zig
@@ -94,12 +94,12 @@ pub fn main(init: std.process.Init) !void {
     clock.sleep(50 * std.time.ns_per_ms); // DB query time
 
     // End the DB span first (child spans should end before parent)
-    db_span.end(null);
+    db_tracer.endSpan(&db_span);
 
     clock.sleep(50 * std.time.ns_per_ms); // HTTP processing time
 
     // End the HTTP span
-    http_span.end(null);
+    http_tracer.endSpan(&http_span);
 
     // Verify spans were created successfully with valid IDs (not all zeros)
     const zero_trace_id = [_]u8{0} ** 16;

--- a/opentelemetry-sdk/src/api/trace/span.zig
+++ b/opentelemetry-sdk/src/api/trace/span.zig
@@ -388,7 +388,8 @@ pub const Span = struct {
         try self.events.append(self.allocator, event);
     }
 
-    /// End the Span
+    /// Record the end timestamp and mark the Span inactive.
+    /// SDK callers complete export through Tracer.endSpan, which also notifies span processors.
     pub fn end(self: *Self, timestamp: ?u64) void {
         if (!self.is_recording) return;
 


### PR DESCRIPTION
## Summary

- end trace example spans through their tracers so configured span processors receive them
- document the distinct roles of `Span.end` and `Tracer.endSpan`

## Testing

- `zig build sdk-test -Dtarget=x86_64-linux-musl` — 289/289 tests passed
- `zig build sdk-examples -Dexamples-filter=simple -Dtarget=x86_64-linux-musl` — exported 2 spans
- `zig build sdk-examples -Dexamples-filter=multiple_tracers -Dtarget=x86_64-linux-musl` — exported 3 spans

Closes #57
