### PR TITLE
Split build steps from execute steps

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,5 +25,7 @@ jobs:
           mirror: 'https://zigmirror.com'
       - name: Fetch dependencies
         run: zig build --fetch
-      - name: Run integration tests
+      - name: Build integration tests
         run: zig build sdk-integration
+      - name: Run integration tests
+        run: zig build sdk-run-integration

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,10 @@ jobs:
         run: zig build sdk-examples
       - name: Run SDK examples
         run: zig build sdk-run-examples
-      - run: zig build semconv-examples
+      - name: Build and install semconv examples
+        run: zig build semconv-examples
+      - name: Run semconv examples
+        run: zig build semconv-run-examples
 
   # Execute bencharmks only if the PR has a specific label 'run::benchmarks'
   benchmarks:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,10 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
           mirror: 'https://zigmirror.com'
       - run: zig build --fetch
-      - run: zig build sdk-examples
+      - name: Build and install SDK examples
+        run: zig build sdk-examples
+      - name: Run SDK examples
+        run: zig build sdk-run-examples
       - run: zig build semconv-examples
 
   # Execute bencharmks only if the PR has a specific label 'run::benchmarks'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,41 +65,57 @@ zig build sdk-test -Dtest-show-logs=true
 
 ### Running integration tests
 
-Integration tests verify the SDK behavior against real OpenTelemetry backends. These tests require Docker to be installed and running.
+Integration tests verify the SDK behavior against real OpenTelemetry backends.
 
-```
+```shell
+# Build and install the integration test binaries to zig-out/bin/integration_tests/
 zig build sdk-integration
+
+# Run them against a real OTLP collector (Docker required)
+zig build sdk-run-integration
+
+# Filter to a specific test by name
+zig build sdk-run-integration -- metrics
 ```
 
 Integration tests are executed as part of CI on pull requests.
 
 > [!IMPORTANT]
-> Integration tests require Docker to be installed and the Docker daemon to be running.
+> `sdk-run-integration` requires Docker to be installed and the Docker daemon to be running.
+> `sdk-integration` alone does not need Docker, since it only builds and installs the binaries.
 
 ### Running examples
 
-Build and run all examples:
+The example workflow follows the same two-step layout as integration tests:
 
-```
+```shell
+# Build every example (Zig + C) and install to zig-out/bin/<category>/<name>
 zig build sdk-examples
+
+# Run the installed binaries
+zig build sdk-run-examples
 ```
+
+Since building always installs to `zig-out/bin/`, any example can also be run directly by hand, e.g. `./zig-out/bin/metrics/histogram`.
 
 #### Examples options
 
-Filter examples to build and run specific ones:
+Filter to specific examples (applies to both `sdk-examples` and `sdk-run-examples`):
 
+```shell
+# Only examples whose name contains "otlp"
+zig build sdk-run-examples -Dexamples-filter=otlp
+
+# Only histogram examples
+zig build sdk-run-examples -Dexamples-filter=histogram
 ```
-# Run only examples matching "otlp"
-zig build sdk-examples -Dexamples-filter=otlp
 
-# Run only histogram examples
-zig build sdk-examples -Dexamples-filter=histogram
-```
-
-Examples are organized by signal type:
+Examples are organized by signal type and language:
 - `opentelemetry-sdk/examples/metrics/` - Metrics API examples
 - `opentelemetry-sdk/examples/trace/` - Tracing API examples
 - `opentelemetry-sdk/examples/logs/` - Logging API examples
+- `opentelemetry-sdk/examples/baggage/`, `opentelemetry-sdk/examples/propagation/` - Context-propagation examples
+- `opentelemetry-sdk/examples/c/` - C-API examples linking against the static library
 
 ### Running benchmarks
 
@@ -169,8 +185,8 @@ A typical development workflow:
 
 1. Make your changes
 2. Run unit tests: `zig build sdk-test`
-3. Run integration tests: `zig build sdk-integration` (if applicable)
-4. Run relevant examples: `zig build sdk-examples -Dexamples-filter=<signal>`
+3. Run integration tests: `zig build sdk-run-integration` (if applicable)
+4. Run relevant examples: `zig build sdk-run-examples -Dexamples-filter=<signal>`
 5. Run benchmarks: `zig build sdk-benchmarks -Doptimize=ReleaseFast` (if performance-critical)
 6. Commit your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,9 +171,12 @@ by hand. See
 is generated and how to regenerate it.
 
 ```
-# Run the semantic conventions tests and examples
+# Run the semantic conventions tests
 zig build semconv-test
+
+# Build and install the examples to zig-out/bin/semconv/, then run them
 zig build semconv-examples
+zig build semconv-run-examples
 
 # Generate docs into zig-out/docs/semconv/
 zig build semconv-docs

--- a/build/helpers.zig
+++ b/build/helpers.zig
@@ -39,3 +39,26 @@ pub const CompilationInfo = struct {
     version: []const u8,
     pkg_name: []const u8,
 };
+
+/// Installs `exe` to zig-out/<install_subdir>/ and hooks that install into
+/// `build_step`, so building never implies running. `run_step` additionally
+/// runs the installed binary, depending on `cwd` for executables (e.g.
+/// integration tests) that must run from a specific working directory.
+pub fn wireExample(
+    b: *std.Build,
+    exe: *std.Build.Step.Compile,
+    install_subdir: []const u8,
+    build_step: *std.Build.Step,
+    run_step: *std.Build.Step,
+    cwd: ?std.Build.LazyPath,
+) void {
+    const install = b.addInstallArtifact(exe, .{
+        .dest_dir = .{ .override = .{ .custom = install_subdir } },
+    });
+    build_step.dependOn(&install.step);
+
+    const run = b.addRunArtifact(exe);
+    if (cwd) |c| run.setCwd(c);
+    run.step.dependOn(&install.step);
+    run_step.dependOn(&run.step);
+}

--- a/build/sdk/build.zig
+++ b/build/sdk/build.zig
@@ -33,10 +33,9 @@ pub fn Setup(
     });
 
     _ = try addTestStep(b, dependencies);
-    _ = try addExamplesStep(b, dependencies, info);
-    _ = try addExamplesCStep(b, sdk_lib, info);
+    try addExamplesStep(b, dependencies, sdk_lib, info);
     _ = try addBenchmarksStep(b, dependencies, info);
-    _ = try addIntegrationStep(b, dependencies, info);
+    try addIntegrationStep(b, dependencies, info);
 
     const docs_step = try addDocsStep(b, dependencies, info);
     docs_step.dependOn(&sdk_lib.step);
@@ -130,9 +129,18 @@ fn addTestStep(b: *std.Build, mods: *const BuildModules) !*std.Build.Step {
     return step;
 }
 
-// Registers the "sdk-examples" step, building and running all Zig examples.
-fn addExamplesStep(b: *std.Build, mods: *const BuildModules, info: CompilationInfo) !*std.Build.Step {
-    const step = b.step("sdk-examples", "Build and run all SDK examples");
+// Registers the "sdk-examples" step (build and install every Zig and C example
+// to zig-out/bin/<category>/, without running them) and the "sdk-run-examples"
+// step (run the installed binaries). Splitting build from run means an example
+// can be built once and then re-run by hand straight from zig-out/bin.
+fn addExamplesStep(
+    b: *std.Build,
+    mods: *const BuildModules,
+    sdk_lib_c: *std.Build.Step.Compile,
+    info: CompilationInfo,
+) !void {
+    const step = b.step("sdk-examples", "Build and install all SDK examples to zig-out/bin/<category>/");
+    const run_step = b.step("sdk-run-examples", "Run installed SDK examples from zig-out");
     const examples_filter = b.option([]const u8, "examples-filter", "Filter examples to build");
 
     const examples_dirs: []const []const u8 = &.{ "metrics", "trace", "logs", "baggage", "propagation" };
@@ -149,17 +157,9 @@ fn addExamplesStep(b: *std.Build, mods: *const BuildModules, info: CompilationIn
         };
         defer b.allocator.free(example);
         for (example) |exe| {
-            const run_example = b.addRunArtifact(exe);
-            step.dependOn(&run_example.step);
+            wireExample(b, exe, b.fmt("bin/{s}", .{example_dir}), step, run_step, null);
         }
     }
-
-    return step;
-}
-
-// Registers the "sdk-examples-c" step, building and running all C examples.
-fn addExamplesCStep(b: *std.Build, sdk_lib_c: *std.Build.Step.Compile, info: CompilationInfo) !*std.Build.Step {
-    const step = b.step("sdk-examples-c", "Build and run SDK C examples");
 
     const c_examples = [_][]const u8{
         "logs",
@@ -193,14 +193,31 @@ fn addExamplesCStep(b: *std.Build, sdk_lib_c: *std.Build.Step.Compile, info: Com
         c_example_exe.root_module.addIncludePath(b.path(sdk_root ++ "/include"));
         c_example_exe.root_module.linkLibrary(sdk_lib_c);
 
-        const run_c_example = b.addRunArtifact(c_example_exe);
-        step.dependOn(&run_c_example.step);
-
-        // Also install each C example executable
-        b.installArtifact(c_example_exe);
+        wireExample(b, c_example_exe, "bin/c", step, run_step, null);
     }
+}
 
-    return step;
+/// Installs `exe` to zig-out/<install_subdir>/ and hooks that install into
+/// `build_step`, so building never implies running. `run_step` additionally
+/// runs the installed binary, depending on `cwd` for executables (integration
+/// tests) that must run from a specific working directory.
+fn wireExample(
+    b: *std.Build,
+    exe: *std.Build.Step.Compile,
+    install_subdir: []const u8,
+    build_step: *std.Build.Step,
+    run_step: *std.Build.Step,
+    cwd: ?std.Build.LazyPath,
+) void {
+    const install = b.addInstallArtifact(exe, .{
+        .dest_dir = .{ .override = .{ .custom = install_subdir } },
+    });
+    build_step.dependOn(&install.step);
+
+    const run = b.addRunArtifact(exe);
+    if (cwd) |c| run.setCwd(c);
+    run.step.dependOn(&install.step);
+    run_step.dependOn(&run.step);
 }
 
 // Registers the "sdk-benchmarks" step, building and running all benchmarks.
@@ -249,9 +266,12 @@ pub fn addBenchmarksStep(b: *std.Build, mods: *const BuildModules, info: Compila
     return step;
 }
 
-// Registers the "sdk-integration" step, building and running integration tests.
-fn addIntegrationStep(b: *std.Build, mods: *const BuildModules, info: CompilationInfo) !*std.Build.Step {
-    const step = b.step("sdk-integration", "Run SDK integration tests (requires Docker)");
+// Registers the "sdk-integration" step (build and install integration tests to
+// zig-out/bin/integration_tests/, without running them) and the
+// "sdk-run-integration" step (run the installed binaries; requires Docker).
+fn addIntegrationStep(b: *std.Build, mods: *const BuildModules, info: CompilationInfo) !void {
+    const step = b.step("sdk-integration", "Build and install SDK integration tests to zig-out/bin/integration_tests/");
+    const run_step = b.step("sdk-run-integration", "Run installed SDK integration tests (requires Docker)");
 
     const integration_tests = buildIntegrationTests(
         b,
@@ -264,12 +284,8 @@ fn addIntegrationStep(b: *std.Build, mods: *const BuildModules, info: Compilatio
     };
     defer b.allocator.free(integration_tests);
     for (integration_tests) |exe| {
-        const run_integration_test = b.addRunArtifact(exe);
-        run_integration_test.setCwd(b.path(sdk_root));
-        step.dependOn(&run_integration_test.step);
+        wireExample(b, exe, "bin/integration_tests", step, run_step, b.path(sdk_root));
     }
-
-    return step;
 }
 
 // Registers the "sdk-docs" step, emitting autodoc for the SDK module.

--- a/build/sdk/build.zig
+++ b/build/sdk/build.zig
@@ -157,7 +157,7 @@ fn addExamplesStep(
         };
         defer b.allocator.free(example);
         for (example) |exe| {
-            wireExample(b, exe, b.fmt("bin/{s}", .{example_dir}), step, run_step, null);
+            helpers.wireExample(b, exe, b.fmt("bin/{s}", .{example_dir}), step, run_step, null);
         }
     }
 
@@ -193,31 +193,8 @@ fn addExamplesStep(
         c_example_exe.root_module.addIncludePath(b.path(sdk_root ++ "/include"));
         c_example_exe.root_module.linkLibrary(sdk_lib_c);
 
-        wireExample(b, c_example_exe, "bin/c", step, run_step, null);
+        helpers.wireExample(b, c_example_exe, "bin/c", step, run_step, null);
     }
-}
-
-/// Installs `exe` to zig-out/<install_subdir>/ and hooks that install into
-/// `build_step`, so building never implies running. `run_step` additionally
-/// runs the installed binary, depending on `cwd` for executables (integration
-/// tests) that must run from a specific working directory.
-fn wireExample(
-    b: *std.Build,
-    exe: *std.Build.Step.Compile,
-    install_subdir: []const u8,
-    build_step: *std.Build.Step,
-    run_step: *std.Build.Step,
-    cwd: ?std.Build.LazyPath,
-) void {
-    const install = b.addInstallArtifact(exe, .{
-        .dest_dir = .{ .override = .{ .custom = install_subdir } },
-    });
-    build_step.dependOn(&install.step);
-
-    const run = b.addRunArtifact(exe);
-    if (cwd) |c| run.setCwd(c);
-    run.step.dependOn(&install.step);
-    run_step.dependOn(&run.step);
 }
 
 // Registers the "sdk-benchmarks" step, building and running all benchmarks.
@@ -284,7 +261,7 @@ fn addIntegrationStep(b: *std.Build, mods: *const BuildModules, info: Compilatio
     };
     defer b.allocator.free(integration_tests);
     for (integration_tests) |exe| {
-        wireExample(b, exe, "bin/integration_tests", step, run_step, b.path(sdk_root));
+        helpers.wireExample(b, exe, "bin/integration_tests", step, run_step, b.path(sdk_root));
     }
 }
 

--- a/build/semconv/build.zig
+++ b/build/semconv/build.zig
@@ -20,7 +20,7 @@ pub fn Setup(
     try dependencies.put("opentelemetry-semconv", semconv_mod);
 
     _ = try addTestStep(b, semconv_mod);
-    _ = try addExamplesStep(b, semconv_mod, info);
+    try addExamplesStep(b, semconv_mod, info);
     _ = try addDocsStep(b, info);
     addGenerateStep(b);
 }
@@ -38,8 +38,12 @@ fn addTestStep(b: *std.Build, semconv_mod: *std.Build.Module) !*std.Build.Step {
     return step;
 }
 
-fn addExamplesStep(b: *std.Build, semconv_mod: *std.Build.Module, info: CompilationInfo) !*std.Build.Step {
-    const step = b.step("semconv-examples", "Build and run all opentelemetry-semconv examples");
+// Registers the "semconv-examples" step (build and install every example to
+// zig-out/bin/semconv/, without running them) and the "semconv-run-examples"
+// step (run the installed binaries).
+fn addExamplesStep(b: *std.Build, semconv_mod: *std.Build.Module, info: CompilationInfo) !void {
+    const step = b.step("semconv-examples", "Build and install all opentelemetry-semconv examples to zig-out/bin/semconv/");
+    const run_step = b.step("semconv-run-examples", "Run installed opentelemetry-semconv examples from zig-out");
 
     const examples_dir = b.path(semconv_root ++ "/examples");
     var dir = try examples_dir.getPath3(b, null).openDir(std.Options.debug_io, "", .{ .iterate = true });
@@ -62,11 +66,8 @@ fn addExamplesStep(b: *std.Build, semconv_mod: *std.Build.Module, info: Compilat
             }),
         });
 
-        const run_example = b.addRunArtifact(example_exe);
-        step.dependOn(&run_example.step);
+        helpers.wireExample(b, example_exe, "bin/semconv", step, run_step, null);
     }
-
-    return step;
 }
 
 fn addDocsStep(b: *std.Build, info: CompilationInfo) !*std.Build.Step {

--- a/opentelemetry-sdk/integration_tests/README.md
+++ b/opentelemetry-sdk/integration_tests/README.md
@@ -23,10 +23,15 @@ Each test executable runs independently with its own:
 
 ## Running the Tests
 
-To run all integration tests:
-
 ```bash
+# Build + install only
 zig build sdk-integration
+
+# Build, install, and run (Docker required)
+zig build sdk-run-integration
+
+# Filter to a single test
+zig build sdk-run-integration -- metrics
 ```
 
 The tests will run with separate collector containers, allowing for parallel execution.
@@ -100,7 +105,7 @@ To add new integration tests:
    - `waitForFile()` - Wait for collector to write output files
    - `waitForFileContent()` - Wait for specific content in output files
    - `readJsonFile()` - Read JSON output files
-4. The test will automatically be discovered and run by `zig build sdk-integration`
+4. The test will automatically be discovered, built by `zig build sdk-integration`, and executed by `zig build sdk-run-integration`
 
 ## Troubleshooting
 
@@ -113,4 +118,5 @@ If you see `error.ConnectionRefused`, check that:
 
 ### Memory Leaks
 
-The tests use a GPA (General Purpose Allocator) with leak detection. If leaks are reported, ensure all resources are properly cleaned up with `defer` statements.
+The tests use a GPA (General Purpose Allocator), that will perform leak detection if built in Debug mode.
+If leaks are reported, ensure all resources are properly cleaned up with `defer` statements.


### PR DESCRIPTION
Allow building examples and integration tests without running them

(Moved and adapted from https://github.com/zig-o11y/opentelemetry-sdk/pull/151)