### PR TITLE
bugfix(config): set correctly service.name

### DIFF
--- a/opentelemetry-sdk/examples/propagation/basic.zig
+++ b/opentelemetry-sdk/examples/propagation/basic.zig
@@ -21,7 +21,7 @@ pub fn main(init: std.process.Init) !void {
 
     // Create a composite propagator from the global configuration
     // This reads OTEL_PROPAGATORS environment variable
-    var propagator = try sdk.propagation.createGlobalPropagator(allocator, init.environ_map);
+    var propagator = try sdk.propagation.createGlobalPropagator(allocator, init.io, init.environ_map);
     defer propagator.deinit();
 
     std.debug.print("Propagator initialized from configuration\n", .{});

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -834,7 +834,7 @@ test "LoggerProvider with config from environment" {
     var env_map = std.process.Environ.Map.init(allocator);
     defer env_map.deinit();
 
-    const cfg = try Configuration.init(allocator, &env_map);
+    const cfg = try Configuration.init(allocator, io, &env_map);
     defer cfg.deinit();
     Configuration.set(cfg);
 

--- a/opentelemetry-sdk/src/api/metrics/meter.zig
+++ b/opentelemetry-sdk/src/api/metrics/meter.zig
@@ -356,7 +356,7 @@ test "meter provider with config from environment" {
     var env_map = std.process.Environ.Map.init(std.testing.allocator);
     defer env_map.deinit();
 
-    const cfg = try Configuration.init(std.testing.allocator, &env_map);
+    const cfg = try Configuration.init(std.testing.allocator, std.testing.io, &env_map);
     defer cfg.deinit();
     Configuration.set(cfg);
 

--- a/opentelemetry-sdk/src/sdk/config.zig
+++ b/opentelemetry-sdk/src/sdk/config.zig
@@ -302,16 +302,13 @@ pub fn set(cfg: *Configuration) void {
 
 /// Initialize configuration from the supplied environment map.
 /// Caller owns the returned Configuration instance and must call deinit() when done.
-pub fn init(allocator: std.mem.Allocator, env_map: *const EnvMap) !*Configuration {
+pub fn init(allocator: std.mem.Allocator, io: std.Io, env_map: *const EnvMap) !*Configuration {
     const cfg = try allocator.create(Configuration);
 
     cfg.* = Configuration{
         .allocator = allocator,
         .sdk_disabled = parseBool(env_map, "OTEL_SDK_DISABLED") orelse false,
-        .service_name = if (env_map.get("OTEL_SERVICE_NAME")) |s|
-            try allocator.dupe(u8, s)
-        else
-            try allocator.dupe(u8, "unknown_service"),
+        .service_name = try resolveServiceName(allocator, io, env_map),
         .resource_attributes = if (env_map.get("OTEL_RESOURCE_ATTRIBUTES")) |s|
             try allocator.dupe(u8, s)
         else
@@ -358,6 +355,44 @@ pub fn deinit(self: *Configuration) void {
 // ============================================================================
 // Parsing Utilities
 // ============================================================================
+
+/// Resolve service.name following the specification precedence:
+/// OTEL_SERVICE_NAME, then a service.name entry in OTEL_RESOURCE_ATTRIBUTES,
+/// then fallback as described by semantic conventions when service.name is not configured.
+/// See https://github.com/open-telemetry/semantic-conventions/blob/main/model/service/registry.yaml.
+///
+/// Caller owns the returned memory.
+fn resolveServiceName(allocator: std.mem.Allocator, io: std.Io, env_map: *const EnvMap) ![]const u8 {
+    if (env_map.get("OTEL_SERVICE_NAME")) |name| return allocator.dupe(u8, name);
+    if (env_map.get("OTEL_RESOURCE_ATTRIBUTES")) |attrs| {
+        if (serviceNameFromResourceAttributes(attrs)) |name| return allocator.dupe(u8, name);
+    }
+    return defaultServiceName(allocator, io);
+}
+
+/// Extract the service.name value from OTEL_RESOURCE_ATTRIBUTES, if present.
+fn serviceNameFromResourceAttributes(attrs: []const u8) ?[]const u8 {
+    var iter = std.mem.splitScalar(u8, attrs, ',');
+    while (iter.next()) |keyVal| {
+        const eq_pos = std.mem.indexOfScalar(u8, keyVal, '=') orelse continue;
+        const key = std.mem.trim(u8, keyVal[0..eq_pos], &std.ascii.whitespace);
+        if (std.mem.eql(u8, key, "service.name")) {
+            return std.mem.trim(u8, keyVal[eq_pos + 1 ..], &std.ascii.whitespace);
+        }
+    }
+    return null;
+}
+
+fn defaultServiceName(allocator: std.mem.Allocator, io: std.Io) ![]const u8 {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const exe_name: ?[]const u8 = if (std.process.executablePath(io, &buf)) |len|
+        std.fs.path.basename(buf[0..len])
+    else |_|
+        null;
+    if (exe_name) |name| {
+        return std.fmt.allocPrint(allocator, "unknown_service:{s}", .{name});
+    } else return allocator.dupe(u8, "unknown_service");
+}
 
 /// Parse a boolean environment variable
 /// Accepts: "true", "1" for true; "false", "0" for false (case-insensitive)
@@ -626,11 +661,11 @@ test "Configuration.init - defaults" {
     var env_map = EnvMap.init(allocator);
     defer env_map.deinit();
 
-    var config = try Configuration.init(allocator, &env_map);
+    var config = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config.deinit();
 
     try std.testing.expectEqual(false, config.sdk_disabled);
-    try std.testing.expectEqualStrings("unknown_service", config.service_name.?);
+    try std.testing.expect(std.mem.startsWith(u8, config.service_name.?, "unknown_service"));
     try std.testing.expectEqual(LogLevel.info, config.log_level);
     try std.testing.expectEqual(@as(usize, 2), config.trace_propagators.len);
 }
@@ -646,7 +681,7 @@ test "Configuration.init - custom values" {
     try env_map.put("OTEL_LOG_LEVEL", "debug");
     try env_map.put("OTEL_TRACES_SAMPLER", "always_on");
 
-    var config = try Configuration.init(allocator, &env_map);
+    var config = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config.deinit();
 
     try std.testing.expectEqual(false, config.sdk_disabled);
@@ -660,7 +695,7 @@ test Configuration {
     var env_map = EnvMap.init(allocator);
     defer env_map.deinit();
 
-    var config = try Configuration.init(allocator, &env_map);
+    var config = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config.deinit();
 
     Configuration.set(config);
@@ -674,15 +709,46 @@ test Configuration {
     try std.testing.expectEqual(config1, config2);
 }
 
-test "Configuration OTEL_SERVICE_NAME default is unknown_service" {
+test "Configuration OTEL_SERVICE_NAME default is unknown_service:<executable>" {
     const allocator = std.testing.allocator;
     var env_map = EnvMap.init(allocator);
     defer env_map.deinit();
 
-    const config = try Configuration.init(allocator, &env_map);
+    const config = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config.deinit();
 
-    try std.testing.expectEqualStrings("unknown_service", config.service_name.?);
+    const name = config.service_name.?;
+    try std.testing.expect(std.mem.startsWith(u8, name, "unknown_service"));
+    if (name.len > "unknown_service".len) {
+        try std.testing.expectEqual(@as(u8, ':'), name["unknown_service".len]);
+        // The concatenated part is a bare executable name, never a path.
+        try std.testing.expect(std.mem.indexOfScalar(u8, name, std.fs.path.sep) == null);
+    }
+}
+
+test "Configuration service.name falls back to OTEL_RESOURCE_ATTRIBUTES before unknown_service" {
+    const allocator = std.testing.allocator;
+    var env_map = EnvMap.init(allocator);
+    defer env_map.deinit();
+    try env_map.put("OTEL_RESOURCE_ATTRIBUTES", "host.name=server-1,service.name=checkout");
+
+    const config = try Configuration.init(allocator, std.testing.io, &env_map);
+    defer config.deinit();
+
+    try std.testing.expectEqualStrings("checkout", config.service_name.?);
+}
+
+test "Configuration OTEL_SERVICE_NAME wins over OTEL_RESOURCE_ATTRIBUTES" {
+    const allocator = std.testing.allocator;
+    var env_map = EnvMap.init(allocator);
+    defer env_map.deinit();
+    try env_map.put("OTEL_SERVICE_NAME", "checkout");
+    try env_map.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=ignored");
+
+    const config = try Configuration.init(allocator, std.testing.io, &env_map);
+    defer config.deinit();
+
+    try std.testing.expectEqualStrings("checkout", config.service_name.?);
 }
 
 const TracerProvider = @import("trace/provider.zig").TracerProvider;
@@ -700,7 +766,7 @@ test "Configuration TracerProvider with SDK disabled" {
     try testMap.put("OTEL_SDK_DISABLED", "true");
 
     // Create configuration with SDK disabled
-    var config_from_env = try Configuration.init(allocator, &testMap);
+    var config_from_env = try Configuration.init(allocator, std.testing.io, &testMap);
     defer config_from_env.deinit();
     Configuration.set(config_from_env);
 
@@ -736,7 +802,7 @@ test "ConfigurationMeterProvider with SDK disabled" {
     defer env_map.deinit();
 
     // Create configuration with SDK disabled
-    var config_from_env = try Configuration.init(allocator, &env_map);
+    var config_from_env = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config_from_env.deinit();
 
     config_from_env.sdk_disabled = true;
@@ -764,7 +830,7 @@ test "Configuration LoggerProvider with SDK disabled" {
     defer env_map.deinit();
 
     // Create configuration with SDK disabled
-    var config_from_env = try Configuration.init(allocator, &env_map);
+    var config_from_env = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config_from_env.deinit();
 
     config_from_env.sdk_disabled = true;
@@ -800,7 +866,7 @@ test "Configuration SDK disabled with OTEL_SDK_DISABLED=false" {
     defer env_map.deinit();
 
     // Create configuration with SDK explicitly enabled
-    var config_from_env = try Configuration.init(allocator, &env_map);
+    var config_from_env = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config_from_env.deinit();
 
     config_from_env.sdk_disabled = false;
@@ -835,7 +901,7 @@ test "Configuration SDK disabled by default is false" {
     defer env_map.deinit();
 
     // Don't set OTEL_SDK_DISABLED - should default to false
-    var config_from_env = try Configuration.init(allocator, &env_map);
+    var config_from_env = try Configuration.init(allocator, std.testing.io, &env_map);
     defer config_from_env.deinit();
 
     // Verify SDK is enabled by default

--- a/opentelemetry-sdk/src/sdk/propagation.zig
+++ b/opentelemetry-sdk/src/sdk/propagation.zig
@@ -156,11 +156,12 @@ pub const CompositePropagator = struct {
 /// it will initialize one from the supplied environment map.
 pub fn createGlobalPropagator(
     allocator: std.mem.Allocator,
+    io: std.Io,
     env_map: *const std.process.Environ.Map,
 ) !CompositePropagator {
     const config = Configuration.get() orelse blk: {
         // No global config exists, create and set one
-        const new_config = try Configuration.init(allocator, env_map);
+        const new_config = try Configuration.init(allocator, io, env_map);
         Configuration.set(new_config);
         break :blk new_config;
     };

--- a/opentelemetry-sdk/src/sdk/resource.zig
+++ b/opentelemetry-sdk/src/sdk/resource.zig
@@ -297,3 +297,41 @@ test "service.name from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME not set"
     try std.testing.expectEqualStrings("key1", resource[1].key);
     try std.testing.expectEqualStrings("value1", resource[1].value.string);
 }
+
+test "service.name from OTEL_RESOURCE_ATTRIBUTES survives resource building" {
+    const allocator = std.testing.allocator;
+
+    var env_map = std.process.Environ.Map.init(allocator);
+    defer env_map.deinit();
+    try env_map.put("OTEL_RESOURCE_ATTRIBUTES", "service.name=checkout,host.name=server-1");
+
+    const config = try Configuration.init(allocator, std.testing.io, &env_map);
+    defer config.deinit();
+
+    const resource = try buildFromConfig(allocator, config);
+    defer freeResource(allocator, resource);
+
+    // service.name is resolved once in the configuration, so it is emitted exactly once.
+    try std.testing.expectEqual(@as(usize, 2), resource.len);
+    try std.testing.expectEqualStrings("service.name", resource[0].key);
+    try std.testing.expectEqualStrings("checkout", resource[0].value.string);
+    try std.testing.expectEqualStrings("host.name", resource[1].key);
+    try std.testing.expectEqualStrings("server-1", resource[1].value.string);
+}
+
+test "service.name defaults to unknown_service when nothing is configured" {
+    const allocator = std.testing.allocator;
+
+    var env_map = std.process.Environ.Map.init(allocator);
+    defer env_map.deinit();
+
+    const config = try Configuration.init(allocator, std.testing.io, &env_map);
+    defer config.deinit();
+
+    const resource = try buildFromConfig(allocator, config);
+    defer freeResource(allocator, resource);
+
+    try std.testing.expectEqual(@as(usize, 1), resource.len);
+    try std.testing.expectEqualStrings("service.name", resource[0].key);
+    try std.testing.expect(std.mem.startsWith(u8, resource[0].value.string, "unknown_service"));
+}

--- a/opentelemetry-sdk/src/sdk/trace/provider.zig
+++ b/opentelemetry-sdk/src/sdk/trace/provider.zig
@@ -511,7 +511,7 @@ test "TracerProvider with config from environment" {
     var env_map = std.process.Environ.Map.init(allocator);
     defer env_map.deinit();
 
-    const cfg = try Configuration.init(allocator, &env_map);
+    const cfg = try Configuration.init(allocator, io, &env_map);
     defer cfg.deinit();
     Configuration.set(cfg);
 


### PR DESCRIPTION
Respect the order by reading env OTEL_SERVICE_NAME, service.name key from OTEL_RESOURCE_ATTRIBUTES and then falling back to what semconv describes.

Closes #64