### PR TITLE
Structured logs

### DIFF
--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -48,6 +48,7 @@ pub const ReadWriteLogRecord = struct {
     attributes: std.ArrayListUnmanaged(Attribute) = .empty,
     resource: ?[]const Attribute = null,
     location: ?std.builtin.SourceLocation = null,
+    event_name: ?[]const u8 = null,
 
     const Self = @This();
 
@@ -76,6 +77,7 @@ pub const ReadWriteLogRecord = struct {
             .resource = self.resource,
             .scope = self.scope,
             .location = self.location,
+            .event_name = self.event_name,
         };
     }
 
@@ -123,6 +125,7 @@ pub const ReadWriteLogRecord = struct {
             .resource = self.resource,
             .scope = self.scope,
             .location = self.location,
+            .event_name = if (self.event_name) |en| try allocator.dupe(u8, en) else null,
         };
     }
 };
@@ -149,6 +152,7 @@ pub const ReadableLogRecord = struct {
     /// points into the Logger's scope
     scope: InstrumentationScope,
     location: ?std.builtin.SourceLocation,
+    event_name: ?[]const u8,
 };
 
 /// SDK LoggerProvider implementation
@@ -418,16 +422,20 @@ pub const Logger = struct {
         options: Options,
     ) void {
         if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) return;
-        self.emitRecord(severity, .{ .string = body }, options);
+        self.emitRecord(severity, null, .{ .string = body }, options);
     }
 
     /// Emit a structured log record whose body is a set of key-value fields.
     /// `data` must be an anonymous struct literal; each field becomes a structured entry in the body.
     /// Field values must be one of: `[]const u8`, `bool`, an integer, or a float (or comptime equivalents).
     ///
+    /// `event_name` identifies the type of event this record represents (e.g. "http.request").
+    /// Structured logs without an event name are hard to navigate as an end-user when viewing logs,
+    /// so prefer passing one; pass `null` only when no meaningful name applies.
+    ///
     /// Example:
     /// ```zig
-    /// logger.emitStructured(.info, .{
+    /// logger.emitStructured(.info, "http.request", .{
     ///     .@"http.method" = "GET",
     ///     .@"http.status" = 200,
     /// }, .{});
@@ -435,6 +443,7 @@ pub const Logger = struct {
     pub fn emitStructured(
         self: *Self,
         severity: ?Severity,
+        event_name: ?[]const u8,
         data: anytype,
         options: Options,
     ) void {
@@ -448,10 +457,10 @@ pub const Logger = struct {
                 .value = structFieldToAttributeValue(@field(data, field.name)),
             };
         }
-        self.emitRecord(severity, .{ .structured = &body_attrs }, options);
+        self.emitRecord(severity, event_name, .{ .structured = &body_attrs }, options);
     }
 
-    fn emitRecord(self: *Self, severity: ?Severity, body: Body, options: Options) void {
+    fn emitRecord(self: *Self, severity: ?Severity, event_name: ?[]const u8, body: Body, options: Options) void {
         const context = options.context orelse getCurrentContext();
 
         // Spec: trace context fields MUST be populated from the resolved Context.
@@ -471,6 +480,7 @@ pub const Logger = struct {
             .resource = self.provider.resource,
             .scope = self.scope,
             .location = options.location,
+            .event_name = event_name,
         };
         defer log_record.deinit(self.allocator);
 
@@ -975,10 +985,12 @@ test "Logger.emitStructured produces structured body with correct fields" {
         found_status: bool = false,
         found_success: bool = false,
         found_duration: bool = false,
+        event_name: ?[]const u8 = null,
 
         pub fn exportLogs(ctx: *anyopaque, records: []ReadableLogRecord) anyerror!void {
             const self: *@This() = @ptrCast(@alignCast(ctx));
             if (records.len == 0) return;
+            self.event_name = records[0].event_name;
             const sb = switch (records[0].body orelse return) {
                 .structured => |kvs| kvs,
                 else => return,
@@ -1022,7 +1034,7 @@ test "Logger.emitStructured produces structured body with correct fields" {
     const scope = InstrumentationScope{ .name = "test-logger" };
     const logger = try provider.getLogger(scope);
 
-    logger.emitStructured(.info, .{
+    logger.emitStructured(.info, "http.request", .{
         .@"http.method" = "GET",
         .@"http.status" = 200,
         .@"http.success" = true,
@@ -1034,4 +1046,5 @@ test "Logger.emitStructured produces structured body with correct fields" {
     try std.testing.expect(mock_exporter.found_status);
     try std.testing.expect(mock_exporter.found_success);
     try std.testing.expect(mock_exporter.found_duration);
+    try std.testing.expectEqualStrings("http.request", mock_exporter.event_name.?);
 }

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -409,6 +409,11 @@ pub const Logger = struct {
         /// file, function name, line, and column at compile time.
         location: ?std.builtin.SourceLocation = null,
 
+        /// Name identifying the class/type of event this record represents (e.g. "http.request").
+        /// A record with a non-empty event name is an OTel "Event"; see
+        /// https://opentelemetry.io/docs/specs/otel/logs/data-model/#events.
+        event_name: ?[]const u8 = null,
+
         /// Propagation context forwarded to log processors on emit.
         /// If null, the active thread-local context is used.
         context: ?Context = null,
@@ -422,28 +427,23 @@ pub const Logger = struct {
         options: Options,
     ) void {
         if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) return;
-        self.emitRecord(severity, null, .{ .string = body }, options);
+        self.emitRecord(severity, .{ .string = body }, options);
     }
 
     /// Emit a structured log record whose body is a set of key-value fields.
     /// `data` must be an anonymous struct literal; each field becomes a structured entry in the body.
     /// Field values must be one of: `[]const u8`, `bool`, an integer, or a float (or comptime equivalents).
     ///
-    /// `event_name` identifies the type of event this record represents (e.g. "http.request").
-    /// Structured logs without an event name are hard to navigate as an end-user when viewing logs,
-    /// so prefer passing one; pass `null` only when no meaningful name applies.
-    ///
     /// Example:
     /// ```zig
-    /// logger.emitStructured(.info, "http.request", .{
+    /// logger.emitStructured(.info, .{
     ///     .@"http.method" = "GET",
     ///     .@"http.status" = 200,
-    /// }, .{});
+    /// }, .{ .event_name = "http.request" });
     /// ```
     pub fn emitStructured(
         self: *Self,
         severity: ?Severity,
-        event_name: ?[]const u8,
         data: anytype,
         options: Options,
     ) void {
@@ -457,10 +457,10 @@ pub const Logger = struct {
                 .value = structFieldToAttributeValue(@field(data, field.name)),
             };
         }
-        self.emitRecord(severity, event_name, .{ .structured = &body_attrs }, options);
+        self.emitRecord(severity, .{ .structured = &body_attrs }, options);
     }
 
-    fn emitRecord(self: *Self, severity: ?Severity, event_name: ?[]const u8, body: Body, options: Options) void {
+    fn emitRecord(self: *Self, severity: ?Severity, body: Body, options: Options) void {
         const context = options.context orelse getCurrentContext();
 
         // Spec: trace context fields MUST be populated from the resolved Context.
@@ -480,7 +480,7 @@ pub const Logger = struct {
             .resource = self.provider.resource,
             .scope = self.scope,
             .location = options.location,
-            .event_name = event_name,
+            .event_name = options.event_name,
         };
         defer log_record.deinit(self.allocator);
 
@@ -1034,12 +1034,12 @@ test "Logger.emitStructured produces structured body with correct fields" {
     const scope = InstrumentationScope{ .name = "test-logger" };
     const logger = try provider.getLogger(scope);
 
-    logger.emitStructured(.info, "http.request", .{
+    logger.emitStructured(.info, .{
         .@"http.method" = "GET",
         .@"http.status" = 200,
         .@"http.success" = true,
         .@"http.duration_ms" = 12.5,
-    }, .{});
+    }, .{ .event_name = "http.request" });
 
     try std.testing.expectEqual(@as(usize, 4), mock_exporter.field_count);
     try std.testing.expect(mock_exporter.found_method);

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -101,7 +101,7 @@ pub const ReadWriteLogRecord = struct {
                 const copy = try allocator.alloc(Attribute, kvs.len);
                 for (kvs, copy) |source, *dest| {
                     dest.* = .{
-                        .key = source.key,
+                        .key = source.key, // shallow copied because it is a static string
                         .value = switch (source.value) {
                             .string => |s| .{ .string = try allocator.dupe(u8, s) },
                             else => source.value,
@@ -460,6 +460,8 @@ pub const Logger = struct {
         self.emitRecord(severity, .{ .structured = &body_attrs }, options);
     }
 
+    // If this function is made public, the body's keys will need to be deep copied
+    // as it would become possible to use dynamically allocated strings as keys
     fn emitRecord(self: *Self, severity: ?Severity, body: Body, options: Options) void {
         const context = options.context orelse getCurrentContext();
 

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -25,6 +25,13 @@ const trace = @import("../trace.zig");
 const Configuration = @import("../../sdk/config.zig").Configuration;
 const resource_attributes = @import("../../sdk/resource.zig");
 
+/// Log record body: either a plain text string or a structured key-value list.
+/// Mirrors the protobuf AnyValue body variants used in OTLP.
+pub const Body = union(enum) {
+    string: []const u8,
+    structured: []const Attribute,
+};
+
 /// ReadWriteLogRecord is a mutable log record used during emission.
 /// Processors can modify this record, and mutations are visible to subsequent processors.
 /// see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecordprocessor
@@ -37,7 +44,7 @@ pub const ReadWriteLogRecord = struct {
     trace_flags: ?u8 = null,
     severity_number: ?u8 = null,
     severity_text: ?[]const u8 = null,
-    body: ?[]const u8 = null,
+    body: ?Body = null,
     attributes: std.ArrayListUnmanaged(Attribute) = .empty,
     resource: ?[]const Attribute = null,
     location: ?std.builtin.SourceLocation = null,
@@ -86,6 +93,23 @@ pub const ReadWriteLogRecord = struct {
                 },
             };
         }
+        const body: ?Body = if (self.body) |b| switch (b) {
+            .string => |s| Body{ .string = try allocator.dupe(u8, s) },
+            .structured => |kvs| blk: {
+                const copy = try allocator.alloc(Attribute, kvs.len);
+                for (kvs, copy) |source, *dest| {
+                    dest.* = .{
+                        .key = source.key,
+                        .value = switch (source.value) {
+                            .string => |s| .{ .string = try allocator.dupe(u8, s) },
+                            else => source.value,
+                        },
+                    };
+                }
+                break :blk Body{ .structured = copy };
+            },
+        } else null;
+
         return .{
             .timestamp = self.timestamp,
             .observed_timestamp = self.observed_timestamp,
@@ -94,7 +118,7 @@ pub const ReadWriteLogRecord = struct {
             .trace_flags = self.trace_flags,
             .severity_number = self.severity_number,
             .severity_text = if (self.severity_text) |t| try allocator.dupe(u8, t) else null,
-            .body = if (self.body) |b| try allocator.dupe(u8, b) else null,
+            .body = body,
             .attributes = attrs,
             .resource = self.resource,
             .scope = self.scope,
@@ -118,7 +142,7 @@ pub const ReadableLogRecord = struct {
     trace_flags: ?u8,
     severity_number: ?u8,
     severity_text: ?[]const u8,
-    body: ?[]const u8,
+    body: ?Body,
     attributes: []const Attribute,
     /// points into the LoggerProvider's resource
     resource: ?[]const Attribute,
@@ -275,6 +299,32 @@ pub const LoggerProvider = struct {
     }
 };
 
+fn structFieldToAttributeValue(v: anytype) AttributeValue {
+    const T = @TypeOf(v);
+    return switch (@typeInfo(T)) {
+        .pointer => |p| switch (p.size) {
+            .slice => if (p.child == u8)
+                .{ .string = v }
+            else
+                @compileError("unsupported slice type for structured log field: " ++ @typeName(T)),
+            .one => switch (@typeInfo(p.child)) {
+                .array => |a| if (a.child == u8)
+                    .{ .string = v } // *const [N:0]u8 string literal
+                else
+                    @compileError("unsupported array type for structured log field: " ++ @typeName(T)),
+                else => @compileError("unsupported pointer type for structured log field: " ++ @typeName(T)),
+            },
+            else => @compileError("unsupported pointer type for structured log field: " ++ @typeName(T)),
+        },
+        .bool => .{ .bool = v },
+        .int => .{ .int = @as(i64, v) },
+        .comptime_int => .{ .int = @as(i64, v) },
+        .float => .{ .double = @as(f64, v) },
+        .comptime_float => .{ .double = @as(f64, v) },
+        else => @compileError("unsupported type for structured log field: " ++ @typeName(T)),
+    };
+}
+
 /// Severity level for a log record.
 ///
 /// Simple variants map to the primary sub-level of each OTel severity group:
@@ -367,10 +417,41 @@ pub const Logger = struct {
         body: []const u8,
         options: Options,
     ) void {
-        if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) {
-            return;
-        }
+        if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) return;
+        self.emitRecord(severity, .{ .string = body }, options);
+    }
 
+    /// Emit a structured log record whose body is a set of key-value fields.
+    /// `data` must be an anonymous struct literal; each field becomes a structured entry in the body.
+    /// Field values must be one of: `[]const u8`, `bool`, an integer, or a float (or comptime equivalents).
+    ///
+    /// Example:
+    /// ```zig
+    /// logger.emitStructured(.info, .{
+    ///     .@"http.method" = "GET",
+    ///     .@"http.status" = 200,
+    /// }, .{});
+    /// ```
+    pub fn emitStructured(
+        self: *Self,
+        severity: ?Severity,
+        data: anytype,
+        options: Options,
+    ) void {
+        if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) return;
+
+        const fields = @typeInfo(@TypeOf(data)).@"struct".fields;
+        var body_attrs: [fields.len]Attribute = undefined;
+        inline for (fields, 0..) |field, i| {
+            body_attrs[i] = .{
+                .key = field.name,
+                .value = structFieldToAttributeValue(@field(data, field.name)),
+            };
+        }
+        self.emitRecord(severity, .{ .structured = &body_attrs }, options);
+    }
+
+    fn emitRecord(self: *Self, severity: ?Severity, body: Body, options: Options) void {
         const context = options.context orelse getCurrentContext();
 
         // Spec: trace context fields MUST be populated from the resolved Context.
@@ -882,4 +963,75 @@ test "LoggerProvider with config from environment" {
     try std.testing.expectEqual(lc.blrp_schedule_delay_ms, batch_processor.scheduled_delay_millis);
     try std.testing.expectEqual(lc.blrp_export_timeout_ms, batch_processor.export_timeout_millis);
     try std.testing.expectEqual(@as(usize, @intCast(lc.blrp_max_export_batch_size)), batch_processor.max_export_batch_size);
+}
+
+test "Logger.emitStructured produces structured body with correct fields" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    const MockExporter = struct {
+        field_count: usize = 0,
+        found_method: bool = false,
+        found_status: bool = false,
+        found_success: bool = false,
+        found_duration: bool = false,
+
+        pub fn exportLogs(ctx: *anyopaque, records: []ReadableLogRecord) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            if (records.len == 0) return;
+            const sb = switch (records[0].body orelse return) {
+                .structured => |kvs| kvs,
+                else => return,
+            };
+            self.field_count = sb.len;
+            for (sb) |attr| {
+                if (std.mem.eql(u8, attr.key, "http.method"))
+                    self.found_method = std.mem.eql(u8, attr.value.string, "GET");
+                if (std.mem.eql(u8, attr.key, "http.status"))
+                    self.found_status = attr.value.int == 200;
+                if (std.mem.eql(u8, attr.key, "http.success"))
+                    self.found_success = attr.value.bool == true;
+                if (std.mem.eql(u8, attr.key, "http.duration_ms"))
+                    self.found_duration = attr.value.double == 12.5;
+            }
+        }
+
+        pub fn shutdown(_: *anyopaque) anyerror!void {}
+
+        pub fn asLogRecordExporter(self: *@This()) LogRecordExporter {
+            return LogRecordExporter{
+                .ptr = self,
+                .vtable = &.{
+                    .exportLogsFn = exportLogs,
+                    .shutdownFn = shutdown,
+                },
+            };
+        }
+    };
+
+    var mock_exporter = MockExporter{};
+    const exporter = mock_exporter.asLogRecordExporter();
+    var processor = SimpleLogRecordProcessor.init(io, exporter);
+    const log_processor = processor.asLogRecordProcessor();
+
+    var provider = try LoggerProvider.init(allocator, io, null);
+    defer provider.deinit();
+
+    try provider.addLogRecordProcessor(log_processor);
+
+    const scope = InstrumentationScope{ .name = "test-logger" };
+    const logger = try provider.getLogger(scope);
+
+    logger.emitStructured(.info, .{
+        .@"http.method" = "GET",
+        .@"http.status" = 200,
+        .@"http.success" = true,
+        .@"http.duration_ms" = 12.5,
+    }, .{});
+
+    try std.testing.expectEqual(@as(usize, 4), mock_exporter.field_count);
+    try std.testing.expect(mock_exporter.found_method);
+    try std.testing.expect(mock_exporter.found_status);
+    try std.testing.expect(mock_exporter.found_success);
+    try std.testing.expect(mock_exporter.found_duration);
 }

--- a/opentelemetry-sdk/src/sdk/logs/exporters/generic.zig
+++ b/opentelemetry-sdk/src/sdk/logs/exporters/generic.zig
@@ -12,7 +12,7 @@ const SerializableLogRecord = struct {
     span_id: ?[8]u8,
     severity_number: ?u8,
     severity_text: ?[]const u8,
-    body: ?[]const u8,
+    body: ?logs.Body,
     scope: InstrumentationScope,
 
     pub fn fromLogRecord(log_record: logs.ReadableLogRecord) SerializableLogRecord {
@@ -92,7 +92,7 @@ test "WriterExporter" {
         var log_record: logs.ReadWriteLogRecord = .{
             .scope = scope,
             .observed_timestamp = 0,
-            .body = "test log message",
+            .body = .{ .string = "test log message" },
             .severity_number = 9,
             .severity_text = "INFO",
         };

--- a/opentelemetry-sdk/src/sdk/logs/exporters/otlp.zig
+++ b/opentelemetry-sdk/src/sdk/logs/exporters/otlp.zig
@@ -274,6 +274,7 @@ pub const OTLPExporter = struct {
             .flags = log_record.trace_flags orelse 0,
             .trace_id = (trace_id_str),
             .span_id = (span_id_str),
+            .event_name = log_record.event_name orelse "",
         };
     }
 
@@ -434,6 +435,7 @@ test "Log record to OTLP conversion with all fields" {
         .resource = null,
         .scope = scope,
         .location = .{ .module = "mylib", .file = "src/mylib.zig", .fn_name = "doWork", .line = 42, .column = 4 },
+        .event_name = "test.event",
     };
 
     var otlp_log = try exporter.logRecordToOTLP(log_record);
@@ -463,6 +465,7 @@ test "Log record to OTLP conversion with all fields" {
     try std.testing.expectEqual(@as(i64, 42), otlp_log.attributes.items[4].value.?.value.?.int_value);
     try std.testing.expectEqualStrings("code.column.number", otlp_log.attributes.items[5].key);
     try std.testing.expectEqual(@as(i64, 4), otlp_log.attributes.items[5].value.?.value.?.int_value);
+    try std.testing.expectEqualStrings("test.event", otlp_log.event_name);
 }
 
 test "Log records grouped by instrumentation scope" {
@@ -496,6 +499,7 @@ test "Log records grouped by instrumentation scope" {
             .resource = null,
             .scope = scope1,
             .location = null,
+            .event_name = null,
         },
         logs.ReadableLogRecord{
             .timestamp = null,
@@ -510,6 +514,7 @@ test "Log records grouped by instrumentation scope" {
             .resource = null,
             .scope = scope2,
             .location = null,
+            .event_name = null,
         },
         logs.ReadableLogRecord{
             .timestamp = null,
@@ -524,6 +529,7 @@ test "Log records grouped by instrumentation scope" {
             .resource = null,
             .scope = scope1,
             .location = null,
+            .event_name = null,
         },
     };
 
@@ -597,6 +603,7 @@ test "Resource attributes in OTLP export" {
             .resource = resource_attrs,
             .scope = scope,
             .location = null,
+            .event_name = null,
         },
     };
 
@@ -646,6 +653,7 @@ test "Trace context binary encoding" {
         .resource = null,
         .scope = scope,
         .location = null,
+        .event_name = null,
     };
 
     var otlp_log = try exporter.logRecordToOTLP(log_record);
@@ -692,6 +700,7 @@ test "Memory cleanup verification" {
             .resource = null,
             .scope = scope,
             .location = null,
+            .event_name = null,
         },
     };
 

--- a/opentelemetry-sdk/src/sdk/logs/exporters/otlp.zig
+++ b/opentelemetry-sdk/src/sdk/logs/exporters/otlp.zig
@@ -206,6 +206,12 @@ pub const OTLPExporter = struct {
                     log_record.attributes.deinit(self.allocator);
                     if (log_record.trace_id.len > 0) self.allocator.free(log_record.trace_id);
                     if (log_record.span_id.len > 0) self.allocator.free(log_record.span_id);
+                    if (log_record.body) |*b| {
+                        if (b.value) |*v| switch (v.*) {
+                            .kvlist_value => |*kv| kv.values.deinit(self.allocator),
+                            else => {},
+                        };
+                    }
                 }
                 scope_log.log_records.deinit(self.allocator);
             }
@@ -243,10 +249,16 @@ pub const OTLPExporter = struct {
             "";
 
         // Convert body to AnyValue
-        const body: ?pbcommon.AnyValue = if (log_record.body) |b|
-            pbcommon.AnyValue{ .value = .{ .string_value = (b) } }
-        else
-            null;
+        const body: ?pbcommon.AnyValue = if (log_record.body) |b| switch (b) {
+            .string => |s| pbcommon.AnyValue{ .value = .{ .string_value = s } },
+            .structured => |kvs| blk: {
+                var kvlist: std.ArrayList(pbcommon.KeyValue) = try .initCapacity(self.allocator, kvs.len);
+                for (kvs) |attr| {
+                    kvlist.appendAssumeCapacity(try attributeToOTLP(attr.key, attr.value));
+                }
+                break :blk pbcommon.AnyValue{ .value = .{ .kvlist_value = .{ .values = kvlist } } };
+            },
+        } else null;
 
         // Use timestamp if available, otherwise use observed_timestamp
         const time_unix_nano = log_record.timestamp orelse log_record.observed_timestamp;
@@ -417,7 +429,7 @@ test "Log record to OTLP conversion with all fields" {
         .trace_flags = null,
         .severity_number = 17, // ERROR
         .severity_text = "ERROR",
-        .body = "Test log message",
+        .body = .{ .string = "Test log message" },
         .attributes = attrs,
         .resource = null,
         .scope = scope,
@@ -479,7 +491,7 @@ test "Log records grouped by instrumentation scope" {
             .trace_flags = null,
             .severity_number = 9,
             .severity_text = "INFO",
-            .body = "Message from lib1",
+            .body = .{ .string = "Message from lib1" },
             .attributes = &[_]attribute.Attribute{},
             .resource = null,
             .scope = scope1,
@@ -493,7 +505,7 @@ test "Log records grouped by instrumentation scope" {
             .trace_flags = null,
             .severity_number = 17,
             .severity_text = "ERROR",
-            .body = "Message from lib2",
+            .body = .{ .string = "Message from lib2" },
             .attributes = &[_]attribute.Attribute{},
             .resource = null,
             .scope = scope2,
@@ -507,7 +519,7 @@ test "Log records grouped by instrumentation scope" {
             .trace_flags = null,
             .severity_number = 9,
             .severity_text = "INFO",
-            .body = "Another message from lib1",
+            .body = .{ .string = "Another message from lib1" },
             .attributes = &[_]attribute.Attribute{},
             .resource = null,
             .scope = scope1,
@@ -580,7 +592,7 @@ test "Resource attributes in OTLP export" {
             .trace_flags = null,
             .severity_number = 9,
             .severity_text = "INFO",
-            .body = "Test message",
+            .body = .{ .string = "Test message" },
             .attributes = &[_]attribute.Attribute{},
             .resource = resource_attrs,
             .scope = scope,
@@ -629,7 +641,7 @@ test "Trace context binary encoding" {
         .trace_flags = null,
         .severity_number = 9,
         .severity_text = "INFO",
-        .body = "Test",
+        .body = .{ .string = "Test" },
         .attributes = &[_]attribute.Attribute{},
         .resource = null,
         .scope = scope,
@@ -675,7 +687,7 @@ test "Memory cleanup verification" {
             .trace_flags = null,
             .severity_number = 9,
             .severity_text = "INFO",
-            .body = "Test",
+            .body = .{ .string = "Test" },
             .attributes = attrs,
             .resource = null,
             .scope = scope,

--- a/opentelemetry-sdk/src/sdk/logs/log_record_processor.zig
+++ b/opentelemetry-sdk/src/sdk/logs/log_record_processor.zig
@@ -702,6 +702,7 @@ test "LogRecordQueue wrap-around split" {
                 .resource = null,
                 .scope = .{ .name = "t" },
                 .location = null,
+                .event_name = null,
             };
         }
     }.make;

--- a/opentelemetry-sdk/src/sdk/logs/log_record_processor.zig
+++ b/opentelemetry-sdk/src/sdk/logs/log_record_processor.zig
@@ -429,7 +429,7 @@ test "SimpleLogRecordProcessor basic functionality" {
     var log_record: logs.ReadWriteLogRecord = .{
         .scope = scope,
         .observed_timestamp = 0,
-        .body = "test log message",
+        .body = .{ .string = "test log message" },
         .severity_number = 9,
     };
     defer log_record.deinit(allocator);
@@ -441,7 +441,7 @@ test "SimpleLogRecordProcessor basic functionality" {
 
     // Verify the log was exported
     try std.testing.expectEqual(@as(usize, 1), mock_exporter.exported_logs.items.len);
-    try std.testing.expectEqualStrings("test log message", mock_exporter.exported_logs.items[0].body.?);
+    try std.testing.expectEqualStrings("test log message", mock_exporter.exported_logs.items[0].body.?.string);
     try std.testing.expectEqual(@as(u8, 9), mock_exporter.exported_logs.items[0].severity_number.?);
 }
 
@@ -481,7 +481,7 @@ test "SimpleLogRecordProcessor with attributes" {
     var log_record: logs.ReadWriteLogRecord = .{
         .scope = scope,
         .observed_timestamp = 0,
-        .body = "log with attributes",
+        .body = .{ .string = "log with attributes" },
     };
     defer log_record.deinit(allocator);
 
@@ -554,7 +554,7 @@ test "BatchingLogRecordProcessor basic functionality" {
         var log_record: logs.ReadWriteLogRecord = .{
             .scope = scope,
             .observed_timestamp = 0,
-            .body = "test log message",
+            .body = .{ .string = "test log message" },
             .severity_number = 9,
         };
         defer log_record.deinit(allocator);
@@ -659,7 +659,7 @@ test "integration: multiple processors in pipeline" {
     var log_record: logs.ReadWriteLogRecord = .{
         .scope = scope,
         .observed_timestamp = 0,
-        .body = "test message",
+        .body = .{ .string = "test message" },
         .severity_number = 9,
     };
     defer log_record.deinit(allocator);


### PR DESCRIPTION
Add an alternative emit method, for a structured log body instead of text. Use a bit of `comptime` magic to have the syntactic sugar of defining the structured body as an anonymous struct.

Also add an `event_name` option to both emit method.

Moved from https://github.com/zig-o11y/opentelemetry-sdk/pull/158

TL;DR:
```zig
    logger.emitStructured(.info, .{
        .@"http.method" = "GET",
        .@"http.status" = 200,
        .@"http.success" = true,
        .@"http.duration_ms" = 12.5,
    }, .{ .event_name = "http.request" });
```