### PR TITLE
trace: add TraceFlags.sampled() constructor

### DIFF
--- a/opentelemetry-sdk/src/api/trace/trace_flags.zig
+++ b/opentelemetry-sdk/src/api/trace/trace_flags.zig
@@ -21,6 +21,13 @@ pub const TraceFlags = struct {
         return Self{ .value = 0 };
     }
 
+    /// Flags for a span the SDK records and exports.
+    /// Distinct from `default()`, which is the zero value used for invalid
+    /// and non-recording span contexts.
+    pub fn sampled() Self {
+        return Self{ .value = SAMPLED_FLAG };
+    }
+
     /// Check if the sampled flag is set
     pub fn isSampled(self: Self) bool {
         return (self.value & SAMPLED_FLAG) != 0;
@@ -72,4 +79,13 @@ test "TraceFlags operations" {
     flags = flags.clearRandom();
     try std.testing.expect(!flags.isSampled());
     try std.testing.expect(!flags.isRandom());
+}
+
+test "TraceFlags sampled constructor" {
+    try std.testing.expect(TraceFlags.sampled().isSampled());
+    try std.testing.expect(!TraceFlags.sampled().isRandom());
+    try std.testing.expectEqual(
+        TraceFlags.default().setSampled().value,
+        TraceFlags.sampled().value,
+    );
 }

--- a/opentelemetry-sdk/src/sdk/trace/provider.zig
+++ b/opentelemetry-sdk/src/sdk/trace/provider.zig
@@ -310,9 +310,9 @@ pub const Tracer = struct {
         }
 
         const trace_flags = if (parent_span_context) |parent_sc|
-            if (parent_sc.isValid()) parent_sc.trace_flags else trace_api.TraceFlags.default().setSampled()
+            if (parent_sc.isValid()) parent_sc.trace_flags else trace_api.TraceFlags.sampled()
         else
-            trace_api.TraceFlags.default().setSampled();
+            trace_api.TraceFlags.sampled();
 
         // Create span context
         const span_context = trace_api.SpanContext.init(


### PR DESCRIPTION
Part of #56 (the API-level ergonomics agreed in
https://github.com/open-telemetry/opentelemetry-zig/issues/56#issuecomment-5465004670;
the SDK-side flag itself landed in #61).

`Tracer.startSpan` builds a recorded span's flags as `default().setSampled()`,
which reads as "the zero value, adjusted" for what is simply the sampled value.
This adds a named constructor next to `default()` and uses it at the two call
sites, so `default()` keeps meaning the zero value that invalid and
non-recording span contexts need.

No behaviour change: `TraceFlags.sampled().value == TraceFlags.default().setSampled().value`,
and a test pins that.

Tests:
- `zig build sdk-test`
- `zig fmt --check` on the two touched files