### PR TITLE
Add a gRPC implementation choice: libgrpc

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -45,8 +45,8 @@
         // with `-Dgrpc-provider=libgrpc`. Lazy so builds using the default
         // (`none`) never fetch it, nor the libgrpc sources it depends on.
         .cgrpc_wrapper = .{
-            .url = "git+https://github.com/agagniere/cgrpc_wrapper?ref=master#32ee939cbe0c74c58adce5f8ed81dd60fe7fb7cb",
-            .hash = "cgrpc_wrapper-0.2.0-O5w4NSmZAAAWtB7fQ8l1lghCY1HHZJyF4P8xL1oityu6",
+            .url = "git+https://github.com/agagniere/cgrpc_wrapper?ref=zig-0.16#dad9b50c882b72fcd91cdd54f6970fb24f7cec69",
+            .hash = "cgrpc_wrapper-0.2.1-O5w4NSmZAAAhyEk5HbO_k5GKPsQQv93tlvZ9fozDc_Sn",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -41,6 +41,14 @@
             .hash = "N-V-__8AAIOkBQAVntdoElRMXVcOsnc-qJUZDDT8auh8Z3aj",
             .lazy = true,
         },
+        // Zig bindings to Google's libgrpc, backing the gRPC transport selected
+        // with `-Dgrpc-provider=libgrpc`. Lazy so builds using the default
+        // (`none`) never fetch it, nor the libgrpc sources it depends on.
+        .cgrpc_wrapper = .{
+            .url = "git+https://github.com/agagniere/cgrpc_wrapper?ref=master#32ee939cbe0c74c58adce5f8ed81dd60fe7fb7cb",
+            .hash = "cgrpc_wrapper-0.2.0-O5w4NSmZAAAWtB7fQ8l1lghCY1HHZJyF4P8xL1oityu6",
+            .lazy = true,
+        },
     },
     .paths = .{
         "build.zig",

--- a/build/helpers.zig
+++ b/build/helpers.zig
@@ -44,6 +44,9 @@ pub const CompilationInfo = struct {
 /// `build_step`, so building never implies running. `run_step` additionally
 /// runs the installed binary, depending on `cwd` for executables (e.g.
 /// integration tests) that must run from a specific working directory.
+///
+/// `shared_libs` lists installs of shared libraries `exe` links: they are
+/// installed before it, and it is given an rpath to find them in zig-out/lib.
 pub fn wireExample(
     b: *std.Build,
     exe: *std.Build.Step.Compile,
@@ -51,14 +54,33 @@ pub fn wireExample(
     build_step: *std.Build.Step,
     run_step: *std.Build.Step,
     cwd: ?std.Build.LazyPath,
+    shared_libs: []const *std.Build.Step.InstallArtifact,
 ) void {
+    // Windows has no rpath: there the run step puts the DLL directories on PATH.
+    if (shared_libs.len > 0 and exe.rootModuleTarget().os.tag != .windows) {
+        exe.root_module.addRPathSpecial(installedLibRpath(b, install_subdir, exe.rootModuleTarget()));
+    }
+
     const install = b.addInstallArtifact(exe, .{
         .dest_dir = .{ .override = .{ .custom = install_subdir } },
     });
+    for (shared_libs) |shared_lib| install.step.dependOn(&shared_lib.step);
     build_step.dependOn(&install.step);
 
     const run = b.addRunArtifact(exe);
     if (cwd) |c| run.setCwd(c);
     run.step.dependOn(&install.step);
     run_step.dependOn(&run.step);
+}
+
+// Rpath letting a binary installed in zig-out/<install_subdir>/ load the shared
+// libraries installed in zig-out/lib/, whatever its working directory is: Zig
+// only records a build-root-relative rpath for the libraries it builds in the
+// cache, which the binary cannot resolve once run from elsewhere.
+fn installedLibRpath(b: *std.Build, install_subdir: []const u8, target: std.Target) []const u8 {
+    // "@executable_path" is the Mach-O spelling of ELF's "$ORIGIN".
+    var rpath: []const u8 = if (target.os.tag.isDarwin()) "@executable_path" else "$ORIGIN";
+    var components = std.mem.tokenizeScalar(u8, install_subdir, '/');
+    while (components.next()) |_| rpath = b.fmt("{s}/..", .{rpath});
+    return b.fmt("{s}/lib", .{rpath});
 }

--- a/build/sdk/build.zig
+++ b/build/sdk/build.zig
@@ -8,7 +8,7 @@ const CompilationInfo = helpers.CompilationInfo;
 // Path of the OpenTelemetry SDK source root directory relative to the build.zig file.
 const sdk_root = "opentelemetry-sdk";
 
-const GrpcProvider = enum { none };
+const GrpcProvider = enum { none, libgrpc };
 
 // Sets up the dependencies, modules and static library for the OpenTelemetry
 // SDK, and installs its artifacts and headers.
@@ -17,7 +17,10 @@ pub fn Setup(
     info: CompilationInfo,
     dependencies: *BuildModules,
 ) !void {
-    try modules(b, info, dependencies);
+    // False on the first pass when the selected gRPC backend is a lazy
+    // dependency that still needs fetching: Zig fetches it and re-runs the
+    // build, so there is nothing left to set up in this pass.
+    if (!try modules(b, info, dependencies)) return;
 
     const sdk_lib = b.addLibrary(.{
         .name = "opentelemetry-sdk",
@@ -43,7 +46,10 @@ pub fn Setup(
     docs_step.dependOn(&sdk_lib.step);
 }
 
-fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !void {
+// Returns false when a lazy dependency needed by the selected gRPC backend is
+// not fetched yet; the caller must then stop configuring, letting Zig fetch it
+// and re-run the build.
+fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !bool {
     const clock_mod = b.createModule(.{
         .root_source_file = b.path(sdk_root ++ "/src/clock.zig"),
         .target = info.target,
@@ -63,6 +69,21 @@ fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !v
             .target = info.target,
             .optimize = info.optimize,
         }),
+        .libgrpc => blk: {
+            // Null on the first pass: Zig fetches the lazy dep and re-runs the build.
+            const cgrpc_dep = b.lazyDependency("cgrpc_wrapper", .{
+                .target = info.target,
+                .optimize = info.optimize,
+            }) orelse return false;
+            break :blk b.createModule(.{
+                .root_source_file = b.path(sdk_root ++ "/src/grpc/libgrpc.zig"),
+                .target = info.target,
+                .optimize = info.optimize,
+                .imports = &.{
+                    .{ .name = "cgrpc_wrapper", .module = cgrpc_dep.module("cgrpc_wrapper") },
+                },
+            });
+        },
     };
     try dependencies.put("grpc_transport", grpc_transport_mod);
 
@@ -114,7 +135,7 @@ fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !v
     });
     try dependencies.put("otlp-stub", otel_stub_mod);
 
-    return;
+    return true;
 }
 
 // Registers the "sdk-test" step, building and running the SDK unit tests.

--- a/build/sdk/build.zig
+++ b/build/sdk/build.zig
@@ -10,6 +10,17 @@ const sdk_root = "opentelemetry-sdk";
 
 const GrpcProvider = enum { none, libgrpc };
 
+// The gRPC backend selected with `-Dgrpc-provider`, and what the binaries
+// linking it need to run.
+const GrpcBackend = struct {
+    provider: GrpcProvider,
+    // Installs of the shared libraries the backend pulls in. libgrpc is built
+    // as a shared library in the build cache, where only a build-root-relative
+    // rpath points at it; installing it under the prefix keeps the binaries in
+    // zig-out able to load it from any working directory.
+    shared_libs: []const *std.Build.Step.InstallArtifact = &.{},
+};
+
 // Sets up the dependencies, modules and static library for the OpenTelemetry
 // SDK, and installs its artifacts and headers.
 pub fn Setup(
@@ -17,10 +28,10 @@ pub fn Setup(
     info: CompilationInfo,
     dependencies: *BuildModules,
 ) !void {
-    // False on the first pass when the selected gRPC backend is a lazy
+    // Null on the first pass when the selected gRPC backend is a lazy
     // dependency that still needs fetching: Zig fetches it and re-runs the
     // build, so there is nothing left to set up in this pass.
-    if (!try modules(b, info, dependencies)) return;
+    const grpc = try modules(b, info, dependencies) orelse return;
 
     const sdk_lib = b.addLibrary(.{
         .name = "opentelemetry-sdk",
@@ -38,18 +49,18 @@ pub fn Setup(
     });
 
     _ = try addTestStep(b, dependencies);
-    try addExamplesStep(b, dependencies, sdk_lib, info);
+    try addExamplesStep(b, dependencies, sdk_lib, info, grpc);
     _ = try addBenchmarksStep(b, dependencies, info);
-    try addIntegrationStep(b, dependencies, info);
+    try addIntegrationStep(b, dependencies, info, grpc);
 
     const docs_step = try addDocsStep(b, dependencies, info);
     docs_step.dependOn(&sdk_lib.step);
 }
 
-// Returns false when a lazy dependency needed by the selected gRPC backend is
-// not fetched yet; the caller must then stop configuring, letting Zig fetch it
-// and re-run the build.
-fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !bool {
+// Returns the selected gRPC backend, or null when a lazy dependency it needs
+// is not fetched yet; the caller must then stop configuring, letting Zig fetch
+// it and re-run the build.
+fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !?GrpcBackend {
     const clock_mod = b.createModule(.{
         .root_source_file = b.path(sdk_root ++ "/src/clock.zig"),
         .target = info.target,
@@ -59,6 +70,7 @@ fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !b
     try dependencies.put("clock", clock_mod);
 
     const grpc_provider = b.option(GrpcProvider, "grpc-provider", "Which gRPC implementation to use, if any") orelse .none;
+    var grpc: GrpcBackend = .{ .provider = grpc_provider };
 
     // The selected gRPC backend is exposed to the SDK as the `grpc_transport`
     // module. Every backend's entry file lives under `opentelemetry-sdk/src/grpc/`
@@ -74,7 +86,20 @@ fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !b
             const cgrpc_dep = b.lazyDependency("cgrpc_wrapper", .{
                 .target = info.target,
                 .optimize = info.optimize,
-            }) orelse return false;
+            }) orelse return null;
+
+            // The very same libgrpc the wrapper links: asking its builder for
+            // the dependency with the arguments it passed itself resolves to
+            // the cached instance rather than configuring a second build of it.
+            const libgrpc = cgrpc_dep.builder.dependency("grpc", .{
+                .target = info.target,
+                .optimize = info.optimize,
+            }).artifact("grpc");
+            grpc.shared_libs = try b.allocator.dupe(
+                *std.Build.Step.InstallArtifact,
+                &.{b.addInstallArtifact(libgrpc, .{})},
+            );
+
             break :blk b.createModule(.{
                 .root_source_file = b.path(sdk_root ++ "/src/grpc/libgrpc.zig"),
                 .target = info.target,
@@ -135,7 +160,7 @@ fn modules(b: *std.Build, info: CompilationInfo, dependencies: *BuildModules) !b
     });
     try dependencies.put("otlp-stub", otel_stub_mod);
 
-    return true;
+    return grpc;
 }
 
 // Registers the "sdk-test" step, building and running the SDK unit tests.
@@ -194,13 +219,18 @@ fn addExamplesStep(
     mods: *const BuildModules,
     sdk_lib_c: *std.Build.Step.Compile,
     info: CompilationInfo,
+    grpc: GrpcBackend,
 ) !void {
     const step = b.step("sdk-examples", "Build and install all SDK examples to zig-out/bin/<category>/");
     const run_step = b.step("sdk-run-examples", "Run installed SDK examples from zig-out");
     const examples_filter = b.option([]const u8, "examples-filter", "Filter examples to build");
 
-    const examples_dirs: []const []const u8 = &.{ "metrics", "trace", "logs", "baggage", "propagation" };
+    const examples_dirs: []const []const u8 = &.{ "metrics", "trace", "logs", "baggage", "propagation", "grpc" };
     for (examples_dirs) |example_dir| {
+        // The gRPC examples export over OTLP/gRPC on every run, which the noop
+        // backend can only fail: build them for a real backend only.
+        if (grpc.provider == .none and std.mem.eql(u8, example_dir, "grpc")) continue;
+
         const example = buildExamples(
             b,
             b.path(b.pathJoin(&.{ sdk_root, "examples", example_dir })),
@@ -213,7 +243,7 @@ fn addExamplesStep(
         };
         defer b.allocator.free(example);
         for (example) |exe| {
-            helpers.wireExample(b, exe, b.fmt("bin/{s}", .{example_dir}), step, run_step, null);
+            helpers.wireExample(b, exe, b.fmt("bin/{s}", .{example_dir}), step, run_step, null, grpc.shared_libs);
         }
     }
 
@@ -249,7 +279,7 @@ fn addExamplesStep(
         c_example_exe.root_module.addIncludePath(b.path(sdk_root ++ "/include"));
         c_example_exe.root_module.linkLibrary(sdk_lib_c);
 
-        helpers.wireExample(b, c_example_exe, "bin/c", step, run_step, null);
+        helpers.wireExample(b, c_example_exe, "bin/c", step, run_step, null, grpc.shared_libs);
     }
 }
 
@@ -302,7 +332,12 @@ pub fn addBenchmarksStep(b: *std.Build, mods: *const BuildModules, info: Compila
 // Registers the "sdk-integration" step (build and install integration tests to
 // zig-out/bin/integration_tests/, without running them) and the
 // "sdk-run-integration" step (run the installed binaries; requires Docker).
-fn addIntegrationStep(b: *std.Build, mods: *const BuildModules, info: CompilationInfo) !void {
+fn addIntegrationStep(
+    b: *std.Build,
+    mods: *const BuildModules,
+    info: CompilationInfo,
+    grpc: GrpcBackend,
+) !void {
     const step = b.step("sdk-integration", "Build and install SDK integration tests to zig-out/bin/integration_tests/");
     const run_step = b.step("sdk-run-integration", "Run installed SDK integration tests (requires Docker)");
 
@@ -311,13 +346,14 @@ fn addIntegrationStep(b: *std.Build, mods: *const BuildModules, info: Compilatio
         b.path(sdk_root ++ "/integration_tests"),
         mods,
         info,
+        grpc.provider,
     ) catch |err| {
         std.debug.print("Error building integration tests: {}\n", .{err});
         return err;
     };
     defer b.allocator.free(integration_tests);
     for (integration_tests) |exe| {
-        helpers.wireExample(b, exe, "bin/integration_tests", step, run_step, b.path(sdk_root));
+        helpers.wireExample(b, exe, "bin/integration_tests", step, run_step, b.path(sdk_root), grpc.shared_libs);
     }
 }
 
@@ -460,6 +496,7 @@ fn buildIntegrationTests(
     integration_dir: std.Build.LazyPath,
     mods: *const BuildModules,
     info: CompilationInfo,
+    grpc_provider: GrpcProvider,
 ) ![]*std.Build.Step.Compile {
     const otel_mod = mods.get("opentelemetry-sdk") orelse return BuildError.ModuleNotFound;
     const clock_mod = mods.get("clock") orelse return BuildError.ModuleNotFound;
@@ -486,6 +523,13 @@ fn buildIntegrationTests(
         .optimize = info.optimize,
         .imports = try helpers.ImportsFromBuildModules(b.allocator, mods, &dep_names),
     });
+    {
+        // Tests covering a transport that may not be compiled in (currently
+        // only gRPC) read this to skip themselves instead of failing.
+        const integration_options = b.addOptions();
+        integration_options.addOption(GrpcProvider, "grpc_provider", grpc_provider);
+        common_mod.addOptions("integration_options", integration_options);
+    }
 
     var iter = test_dir.iterate();
     while (try iter.next(std.Options.debug_io)) |file| {

--- a/build/semconv/build.zig
+++ b/build/semconv/build.zig
@@ -66,7 +66,7 @@ fn addExamplesStep(b: *std.Build, semconv_mod: *std.Build.Module, info: Compilat
             }),
         });
 
-        helpers.wireExample(b, example_exe, "bin/semconv", step, run_step, null);
+        helpers.wireExample(b, example_exe, "bin/semconv", step, run_step, null, &.{});
     }
 }
 

--- a/opentelemetry-sdk/examples/grpc/all_signals.zig
+++ b/opentelemetry-sdk/examples/grpc/all_signals.zig
@@ -1,0 +1,168 @@
+//! OTLP/gRPC example — metrics, traces, and logs from one binary.
+//!
+//! Simulates a small HTTP server handling three requests, exporting all signals
+//! over OTLP/gRPC to a local collector.
+//!
+//! This directory is only built when a real gRPC backend is selected, since the
+//! default (`none`) provider fails every export:
+//!   zig build sdk-examples -Dgrpc-provider=libgrpc -Dexamples-filter=all_signals
+//!   ./zig-out/bin/grpc/all_signals
+//!
+//! Collector (plain Docker):
+//!   docker run --rm -p 4317:4317 otel/opentelemetry-collector
+//!
+//! The gRPC endpoint defaults to localhost:4317. Override with:
+//!   OTEL_EXPORTER_OTLP_ENDPOINT=<host:port> ./zig-out/bin/grpc/all_signals
+
+const std = @import("std");
+const clock = @import("clock");
+const sdk = @import("opentelemetry-sdk");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+
+    const sdk_config = try sdk.config.init(allocator, io, init.environ_map);
+    defer sdk_config.deinit();
+    sdk.config.set(sdk_config);
+
+    var config = try sdk.otlp.ConfigOptions.init(allocator, init.environ_map);
+    defer config.deinit();
+
+    config.protocol = .grpc;
+    // Switch to the gRPC port unless the user already set OTEL_EXPORTER_OTLP_ENDPOINT.
+    if (std.mem.eql(u8, config.endpoint, "localhost:4318")) {
+        config.endpoint = "localhost:4317";
+    }
+
+    std.log.info("exporting to {s} via gRPC", .{config.endpoint});
+
+    // ── Metrics ──────────────────────────────────────────────────────────────
+
+    const mp = try sdk.metrics.MeterProvider.init(allocator, io);
+    defer mp.shutdown();
+    const me = try sdk.metrics.MetricExporter.OTLP(allocator, io, null, null, config);
+    defer me.otlp.deinit();
+    const mr = try sdk.metrics.MetricReader.init(allocator, io, me.exporter);
+    defer mr.shutdown();
+    try mp.addReader(mr);
+
+    const meter = try mp.getMeter(.{ .name = "grpc-example", .version = "1.0.0" });
+    var req_count = try meter.createCounter(u64, .{
+        .name = "http.server.requests",
+        .description = "Total HTTP requests handled",
+    });
+    var req_duration = try meter.createHistogram(f64, .{
+        .name = "http.server.duration",
+        .description = "HTTP request duration",
+        .unit = "ms",
+    });
+
+    // ── Traces ───────────────────────────────────────────────────────────────
+
+    var prng = std.Random.DefaultPrng.init(@intCast(clock.milliTimestamp()));
+    const id_generator = sdk.trace.IDGenerator{
+        .Random = sdk.trace.RandomIDGenerator.init(prng.random()),
+    };
+    var tracer_provider = try sdk.trace.TracerProvider.init(allocator, io, id_generator);
+    defer tracer_provider.shutdown();
+    var trace_exporter = try sdk.trace.OTLPExporter.init(allocator, io, config);
+    defer trace_exporter.deinit();
+    var span_processor = sdk.trace.SimpleProcessor.init(
+        allocator,
+        io,
+        trace_exporter.asSpanExporter(),
+    );
+    try tracer_provider.addSpanProcessor(span_processor.asSpanProcessor());
+    const tracer = try tracer_provider.getTracer(.{ .name = "grpc-example", .version = "1.0.0" });
+
+    // ── Logs ─────────────────────────────────────────────────────────────────
+
+    const resource_attrs = try sdk.Attributes.from(allocator, .{
+        "host.name", @as([]const u8, "my-computer"),
+    });
+    defer if (resource_attrs) |attrs| allocator.free(attrs);
+    var logs_exporter = try sdk.logs.OTLPExporter.init(allocator, io, config);
+    defer logs_exporter.deinit();
+    var log_processor = sdk.logs.SimpleLogRecordProcessor.init(
+        io,
+        logs_exporter.asLogRecordExporter(),
+    );
+    var logger_provider = try sdk.logs.LoggerProvider.init(allocator, io, resource_attrs);
+    defer logger_provider.deinit();
+    try logger_provider.addLogRecordProcessor(log_processor.asLogRecordProcessor());
+    const logger = try logger_provider.getLogger(sdk.scope.InstrumentationScope{
+        .name = "grpc-example",
+        .version = "1.0.0",
+    });
+
+    // ── Simulate request handling ─────────────────────────────────────────────
+
+    logger.emit(.info, "server started", .{});
+
+    const requests = [_]struct {
+        method: []const u8,
+        path: []const u8,
+        latency_ms: f64,
+    }{
+        .{ .method = "GET", .path = "/api/users", .latency_ms = 12.4 },
+        .{ .method = "POST", .path = "/api/orders", .latency_ms = 87.2 },
+        .{ .method = "GET", .path = "/api/items", .latency_ms = 5.1 },
+    };
+
+    for (requests) |req| {
+        var span = try tracer.startSpan(allocator, req.path, .{ .kind = .Server });
+        defer span.deinit();
+        try span.setAttribute("http.method", .{ .string = req.method });
+        try span.setAttribute("http.route", .{ .string = req.path });
+        try span.setAttribute("example.source", .{ .string = "grpc-all-signals" });
+
+        logger.emitStructured(.info, .{
+            .method = req.method,
+            .path = req.path,
+            .duration = req.latency_ms,
+        }, .{ .span_context = span.span_context });
+
+        clock.sleep(@as(u64, @intFromFloat(req.latency_ms * std.time.ns_per_ms)));
+
+        try req_count.add(1, .{
+            "http.method", req.method,
+            "http.route",  req.path,
+        });
+        try req_duration.record(req.latency_ms, .{
+            "http.method", req.method,
+            "http.route",  req.path,
+        });
+
+        span.setStatus(sdk.api.trace.Status.ok());
+        tracer.endSpan(&span);
+
+        var trace_buf: [32]u8 = undefined;
+        var span_buf: [16]u8 = undefined;
+        std.log.info("{s} {s} — {d:.1} ms  trace={s} span={s}", .{
+            req.method,
+            req.path,
+            req.latency_ms,
+            span.span_context.trace_id.toHex(&trace_buf),
+            span.span_context.span_id.toHex(&span_buf),
+        });
+    }
+
+    logger.emitStructured(.warn, .{
+        .path = @as([]const u8, "/api/orders"),
+        .duration = @as(f64, 87.2),
+        .threshold = @as(f64, 50.0),
+    }, .{});
+    logger.emit(.info, "server shutting down", .{});
+
+    // Flush all three pipelines. The simple processors log and swallow their
+    // export failures; do the same here so a missing collector ends the
+    // example with a hint rather than a stack trace.
+    mr.collect() catch |err| std.log.err(
+        "metrics flush failed: {t} — is a collector listening on {s}?",
+        .{ err, config.endpoint },
+    );
+    logger_provider.shutdown() catch |err| std.log.err("logs flush failed: {t}", .{err});
+
+    std.log.info("done", .{});
+}

--- a/opentelemetry-sdk/integration_tests/README.md
+++ b/opentelemetry-sdk/integration_tests/README.md
@@ -10,6 +10,7 @@ The integration tests are split into separate test executables that can run in p
 - `metrics.zig` - Metrics export tests (uncompressed and gzip-compressed)
 - `traces.zig` - Traces export tests (uncompressed and gzip-compressed)
 - `logs.zig` - Logs export tests (uncompressed and gzip-compressed)
+- `logs_grpc.zig` - Logs export over OTLP/gRPC, which needs a gRPC backend compiled in (see below)
 
 Each test executable runs independently with its own:
 - Unique Docker container (named `otel-test-{signal}-{timestamp}-{random}`)
@@ -35,6 +36,17 @@ zig build sdk-run-integration -- metrics
 ```
 
 The tests will run with separate collector containers, allowing for parallel execution.
+
+### Tests Needing a gRPC Backend
+
+The SDK is built without a gRPC implementation by default, so every export over
+OTLP/gRPC fails with `UnimplementedTransportProtocol`. Tests of that transport
+(`logs_grpc.zig`) print a warning and exit successfully in that configuration,
+and exercise the transport when a backend is selected:
+
+```bash
+zig build sdk-run-integration -Dgrpc-provider=libgrpc -- logs_grpc
+```
 
 ## What the Tests Do
 

--- a/opentelemetry-sdk/integration_tests/common.zig
+++ b/opentelemetry-sdk/integration_tests/common.zig
@@ -1,8 +1,14 @@
 const std = @import("std");
 const clock = @import("clock");
+const integration_options = @import("integration_options");
 
 pub const COLLECTOR_HTTP_PORT = "4318";
 pub const COLLECTOR_GRPC_PORT = "4317";
+
+/// gRPC backend the SDK under test was built with (`-Dgrpc-provider`).
+/// Tests exercising the gRPC transport should skip themselves when it is
+/// `.none`, since every export then fails with UnimplementedTransportProtocol.
+pub const grpc_provider = integration_options.grpc_provider;
 
 /// Context for running integration tests with a containerized collector
 pub const TestContext = struct {

--- a/opentelemetry-sdk/integration_tests/logs_grpc.zig
+++ b/opentelemetry-sdk/integration_tests/logs_grpc.zig
@@ -1,0 +1,133 @@
+//! Integration test for OTLP/gRPC logs export.
+//!
+//! Requires the SDK to be built with `-Dgrpc-provider=libgrpc`. With the
+//! default (`none`) provider this binary self-skips: it prints a warning and
+//! exits 0, so it can sit in the same CI matrix as the HTTP integration tests
+//! without forcing them to know about the gRPC backend.
+//!
+//! Run with:
+//!   zig build sdk-run-integration -Dgrpc-provider=libgrpc -- logs_grpc
+
+const std = @import("std");
+const clock = @import("clock");
+const sdk = @import("opentelemetry-sdk");
+const logs_sdk = sdk.logs;
+const common = @import("common");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+
+    if (common.grpc_provider == .none) {
+        std.debug.print(
+            "⚠ Skipping logs_grpc: SDK built with -Dgrpc-provider=none. " ++
+                "Re-run with -Dgrpc-provider=libgrpc to exercise the gRPC transport.\n",
+            .{},
+        );
+        return;
+    }
+
+    var ctx = try common.setupTestContext(allocator, io, "logs-grpc");
+    defer common.cleanupTestContext(&ctx, io);
+
+    std.debug.print("Running logs gRPC integration test...\n", .{});
+    try testLogsOverGrpc(allocator, io, init.environ_map, ctx.tmp_dir);
+    std.debug.print("✓ Logs gRPC test passed\n\n", .{});
+}
+
+fn testLogsOverGrpc(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    env_map: *const std.process.Environ.Map,
+    tmp_dir: std.Io.Dir,
+) !void {
+    var config = try sdk.otlp.ConfigOptions.init(allocator, env_map);
+    defer config.deinit();
+
+    // Talk to the collector's gRPC port, in plaintext. We deliberately leave
+    // `config.insecure` unset so the default credential-selection logic
+    // applies: a localhost endpoint with no TLS material falls back to
+    // LOCAL_TCP, which is plaintext but loopback-only — the exact path most
+    // dev setups will hit.
+    config.protocol = .grpc;
+    config.endpoint = "localhost:" ++ common.COLLECTOR_GRPC_PORT;
+
+    var otlp_exporter = try logs_sdk.OTLPExporter.init(allocator, io, config);
+    defer otlp_exporter.deinit();
+    const exporter = otlp_exporter.asLogRecordExporter();
+
+    var simple_processor = logs_sdk.SimpleLogRecordProcessor.init(io, exporter);
+    const processor = simple_processor.asLogRecordProcessor();
+
+    const service_name: []const u8 = "integration-test-grpc";
+    const resource_attrs = try sdk.Attributes.from(allocator, .{
+        "service.name", service_name,
+    });
+    defer if (resource_attrs) |attrs| allocator.free(attrs);
+
+    var provider = try logs_sdk.LoggerProvider.init(allocator, io, resource_attrs);
+    defer provider.deinit();
+
+    try provider.addLogRecordProcessor(processor);
+
+    const scope = sdk.scope.InstrumentationScope{
+        .name = "integration-test-grpc",
+        .version = "1.0.0",
+    };
+    const logger = try provider.getLogger(scope);
+
+    const num_logs = 5;
+    logger.emit(.trace, "gRPC trace log", .{ .severity_text = "TRACE" });
+    logger.emit(.debug, "gRPC debug log", .{});
+    logger.emit(.info, "gRPC info log", .{});
+    logger.emit(.warn, "gRPC warning log", .{ .severity_text = "WARNING" });
+    logger.emit(.err, "gRPC error log", .{});
+
+    const attrs = [_]sdk.attributes.Attribute{
+        .{ .key = "transport", .value = .{ .string = "grpc" } },
+        .{ .key = "test.iteration", .value = .{ .int = 1 } },
+    };
+    logger.emit(.info, "gRPC log with attributes", .{ .attributes = &attrs });
+
+    try provider.shutdown();
+
+    clock.sleep(1 * std.time.ns_per_s);
+
+    std.debug.print("  Sent {d} log records over gRPC\n", .{num_logs + 1});
+    std.debug.print("  Waiting for logs JSON file...\n", .{});
+
+    const json_content = common.waitForFileContent(allocator, io, tmp_dir, "logs.json", "gRPC info log", 15) catch |err| {
+        if (err == error.ExpectedContentNotFound) {
+            const stale_content = common.readJsonFile(allocator, io, tmp_dir, "logs.json") catch {
+                std.debug.print("  ERROR: Could not read logs.json\n", .{});
+                return error.LogsNotReceivedByCollector;
+            };
+            defer allocator.free(stale_content);
+            std.debug.print("  ERROR: gRPC logs JSON doesn't contain expected data\n", .{});
+            std.debug.print("  JSON content sample (first 500 chars):\n{s}\n", .{stale_content[0..@min(stale_content.len, 500)]});
+            return error.LogsNotReceivedByCollector;
+        }
+        return err;
+    };
+    defer allocator.free(json_content);
+
+    const has_grpc_log = std.mem.indexOf(u8, json_content, "gRPC info log") != null;
+    const has_resource_logs = std.mem.indexOf(u8, json_content, "resourceLogs") != null or
+        std.mem.indexOf(u8, json_content, "resource_logs") != null;
+    const has_service_name = std.mem.indexOf(u8, json_content, "integration-test-grpc") != null;
+    const has_transport_attr = std.mem.indexOf(u8, json_content, "grpc") != null;
+
+    if (!has_grpc_log or !has_resource_logs or !has_service_name) {
+        std.debug.print("  ERROR: gRPC logs JSON doesn't contain expected data\n", .{});
+        std.debug.print("  has_grpc_log={}, has_resource_logs={}, has_service_name={}\n", .{
+            has_grpc_log, has_resource_logs, has_service_name,
+        });
+        std.debug.print("  JSON content sample (first 500 chars):\n{s}\n", .{json_content[0..@min(json_content.len, 500)]});
+        return error.LogsNotReceivedByCollector;
+    }
+
+    std.debug.print("  ✓ gRPC logs JSON validated - found expected log records\n", .{});
+    if (has_transport_attr) {
+        std.debug.print("  ✓ Transport attribute 'grpc' present\n", .{});
+    }
+}

--- a/opentelemetry-sdk/src/grpc/libgrpc.zig
+++ b/opentelemetry-sdk/src/grpc/libgrpc.zig
@@ -1,0 +1,151 @@
+//! gRPC transport backed by Google's libgrpc (via the `cgrpc_wrapper`
+//! Zig bindings). Selected by `-Dgrpc-provider=libgrpc`.
+
+const std = @import("std");
+const grpc = @import("cgrpc_wrapper");
+
+const Allocator = std.mem.Allocator;
+
+const log = std.log.scoped(.grpc_transport);
+
+const configuration = @import("config.zig");
+pub const Configuration = configuration.Configuration;
+
+/// Send a pre-encoded protobuf payload to a gRPC endpoint.
+///
+/// `path` is the gRPC method path, e.g. "/package.Service/Method".
+/// `data` is the raw protobuf-encoded request body.
+/// `io` is used to read PEM files for SSL credentials (if configured); the
+/// actual gRPC call goes through libgrpc's own thread pool.
+pub fn send(
+    gpa: Allocator,
+    io: std.Io,
+    path: []const u8,
+    data: []const u8,
+    config: Configuration,
+) !void {
+    // TODO: do it once globally
+    grpc.init();
+    defer grpc.deinit();
+
+    var arena_instance: std.heap.ArenaAllocator = .init(gpa);
+    defer arena_instance.deinit();
+    const arena = arena_instance.allocator();
+
+    const endpoint: [:0]u8 = try arena.dupeZ(u8, config.endpoint);
+
+    var credentials: grpc.client.Credentials = try makeCredentials(arena, io, config);
+    defer credentials.deinit();
+
+    var channel: grpc.Channel = try grpc.Channel.init(endpoint, credentials);
+    defer channel.deinit();
+
+    var queue: grpc.PluckQueue = .init();
+    defer queue.deinit();
+    defer queue.shutdown();
+
+    const deadline: grpc.Deadline = .{ .duration = .fromSeconds(@intCast(config.timeout_sec)) };
+    switch (try grpc.client.rawUnaryCall(gpa, &channel, &queue, path, data, deadline)) {
+        // TODO: handle partial success.
+        // See https://opentelemetry.io/docs/specs/otlp/#partial-success
+        .success => |bytes| if (bytes) |b| gpa.free(b),
+        .failure => |f| {
+            defer gpa.free(f.details);
+            log.err("gRPC error {}: {s}", .{ f.code, f.details });
+            // Retryable codes per OTLP spec:
+            // https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-response
+            // TODO: actually perform the retry (with exp. backoff) instead of
+            // delegating it to the caller. Ideally the retry loop lives in a
+            // transport-agnostic layer shared with the HTTP transport.
+            return switch (f.toZigError()) {
+                error.Cancelled,
+                error.DeadlineExceeded,
+                error.Aborted,
+                error.OutOfRange,
+                error.Unavailable,
+                error.DataLoss,
+                // RESOURCE_EXHAUSTED is retryable only when the server signals
+                // it via RetryInfo; we don't parse trailers, so treat as retryable.
+                error.ResourceExhausted,
+                => error.RetryableStatusCodeInResponse,
+                else => error.NonRetryableStatusCodeInResponse,
+            };
+        },
+        .operation_failed => {
+            log.err("gRPC batch operation failed (no status available)", .{});
+            return error.NonRetryableStatusCodeInResponse;
+        },
+        // Local deadline elapsed: transient by definition.
+        .timeout => return error.RetryableStatusCodeInResponse,
+    }
+}
+
+/// Builds the gRPC channel credentials for the given configuration.
+/// The decision is made by `configuration.pickCredential`; this function only
+/// constructs the credential object the decision points to.
+///
+/// TODO: support UDS endpoints (e.g. "unix:/var/run/otel.sock"). Over UDS,
+/// libgrpc's LOCAL credentials provide PRIVACY_AND_INTEGRITY (the TCP variant
+/// used here only checks the peer is loopback and provides no encryption).
+fn makeCredentials(arena: Allocator, io: std.Io, config: Configuration) !grpc.client.Credentials {
+    const choice = configuration.pickCredential(config);
+    log.debug("Selecting {t} credentials", .{choice});
+    return switch (choice) {
+        .insecure => .insecure(),
+        // local_tcp is plaintext, but gRPC rejects the connection at handshake
+        // time when the peer is not on loopback — so a misconfigured remote
+        // endpoint fails closed instead of silently exfiltrating cleartext.
+        .local_tcp => .localTCP(),
+        .local_uds => .localUDS(),
+        .ssl => makeSSLCredentials(arena, io, config),
+    };
+}
+
+fn readFile(allocator: Allocator, io: std.Io, filename: []const u8) ![:0]u8 {
+    const max_size: usize = 1 << 20; // 1MiB
+
+    return std.Io.Dir.cwd().readFileAllocOptions(
+        io,
+        filename,
+        allocator,
+        .limited(max_size),
+        .of(u8),
+        0,
+    );
+}
+
+/// Builds SSL credentials from the configured PEM files.
+///
+/// Lifetime: gRPC copies `pem_root_certs` internally, but the client
+/// `cert_chain` and `private_key` buffers passed via SSLKeyCertPair are
+/// retained by reference (see grpc/src/core/credentials/transport/ssl/
+/// ssl_credentials.cc::build_config). They must outlive the returned
+/// credentials. The caller passes an arena freed only after
+/// `credentials.deinit()` to satisfy this — `send()` arranges that ordering.
+fn makeSSLCredentials(arena: Allocator, io: std.Io, config: Configuration) !grpc.client.Credentials {
+    var root_certs: ?[:0]u8 = null;
+    var client_key_cert: ?*grpc.SSLKeyCertPair = null;
+
+    if (config.server_root_certificates_filename) |filename|
+        root_certs = try readFile(arena, io, filename);
+    if ((config.client_certificate_filename == null) != (config.client_private_key_filename == null))
+        log.warn("Inconsistent configuration of the client key and certificate, either provide both or neither", .{});
+    if (config.client_certificate_filename) |cert_filename| {
+        if (config.client_private_key_filename) |key_filename| {
+            client_key_cert = try arena.create(grpc.SSLKeyCertPair);
+            client_key_cert.?.private_key = try readFile(arena, io, key_filename);
+            client_key_cert.?.certificate_chain = try readFile(arena, io, cert_filename);
+        }
+    }
+    log.debug("SSL: {s}, {s} a client key/certificate pair", .{
+        if (root_certs != null) "using configured server root certificates" else "using server root certificates from GRPC_DEFAULT_SSL_ROOTS_FILE_PATH or system directories",
+        if (client_key_cert != null) "with" else "without",
+    });
+    return .ssl(root_certs, client_key_cert);
+}
+
+test {
+    // Pull config tests into this module's test suite so they run regardless
+    // of which gRPC backend is selected at build time.
+    _ = @import("config.zig");
+}

--- a/opentelemetry-sdk/src/grpc/noop.zig
+++ b/opentelemetry-sdk/src/grpc/noop.zig
@@ -9,6 +9,7 @@ pub const Configuration = @import("config.zig").Configuration;
 
 pub fn send(
     _: std.mem.Allocator,
+    _: std.Io,
     _: []const u8,
     _: []const u8,
     _: Configuration,
@@ -19,7 +20,7 @@ pub fn send(
 test "noop send always reports UnimplementedTransportProtocol" {
     try std.testing.expectError(
         error.UnimplementedTransportProtocol,
-        send(std.testing.allocator, "/some/Service/Method", "payload", .{}),
+        send(std.testing.allocator, std.testing.io, "/some.Service/Method", "payload", .{}),
     );
 }
 

--- a/opentelemetry-sdk/src/otlp.zig
+++ b/opentelemetry-sdk/src/otlp.zig
@@ -893,7 +893,7 @@ pub fn Export(
 
             break :blk http_client.send(url, payload);
         },
-        .grpc => grpc_transport.send(allocator, otlp_payload.signal().grpcPath(), payload, .{
+        .grpc => grpc_transport.send(allocator, io, otlp_payload.signal().grpcPath(), payload, .{
             .endpoint = config.endpoint,
             .insecure = config.insecure,
             .timeout_sec = config.timeout_sec,


### PR DESCRIPTION
Closes #13 

Wire the `libgrpc` value of `-Dgrpc-provider` to a real transport backed by Google's libgrpc, through the `cgrpc_wrapper` Zig bindings (a lazy dependency, so default builds never fetch it nor the libgrpc sources).

The transport performs a raw unary call with the pre-encoded protobuf payload, maps non-OK statuses to retryable/non-retryable errors per the OTLP spec, and builds channel credentials from the shared `grpc/config.zig` decision.

Reading PEM files needs an `Io`, so `send` takes one; the noop backend and the `otlp.Export` call site are updated accordingly.

Split and adapted from https://github.com/zig-o11y/opentelemetry-sdk/pull/140

Remaining:
- [x] example
- [x] integration test
- [x] bump to latest gRPC
- [ ] Document in README
- [ ] Correctly handle the dynamic lib loading for integration tests