### PR TITLE
Proposal: Attributes builder

### DIFF
--- a/build/sdk/build.zig
+++ b/build/sdk/build.zig
@@ -359,6 +359,7 @@ fn buildExamples(
                 "opentelemetry-sdk",
                 "otlp-stub",
                 "opentelemetry-proto",
+                "opentelemetry-semconv",
                 "clock",
             };
 

--- a/opentelemetry-sdk/examples/logs/structured.zig
+++ b/opentelemetry-sdk/examples/logs/structured.zig
@@ -1,0 +1,168 @@
+//! Shows the ways of shaping a log record: a plain string body or a structured one,
+//! with attributes written by hand or derived from a struct literal at compile time.
+
+const std = @import("std");
+const sdk = @import("opentelemetry-sdk");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
+
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+
+    var print_exporter = PrintExporter.init(&stdout_writer.interface);
+    var simple_processor = sdk.logs.SimpleLogRecordProcessor.init(io, print_exporter.asLogRecordExporter());
+
+    var provider = try sdk.logs.LoggerProvider.init(allocator, io, null);
+    defer provider.deinit();
+    try provider.addLogRecordProcessor(simple_processor.asLogRecordProcessor());
+
+    const logger = try provider.getLogger(.{ .name = "example.structured", .version = "1.0.0" });
+
+    // 1. A plain string body: what a log line looks like in most logging libraries.
+    heading("plain body");
+    logger.emit(.info, "Application started", .{});
+
+    // 2. Attributes written by hand, one Attribute per key.
+    heading("plain body, attributes written by hand");
+    const server_attrs = [_]sdk.attributes.Attribute{
+        .{ .key = "server.address", .value = .{ .string = "localhost" } },
+        .{ .key = "server.port", .value = .{ .int = 8080 } },
+    };
+    logger.emit(.info, "Listening for connections", .{ .attributes = &server_attrs });
+
+    // 3. The same list from a struct literal. Nested literals become the dot-delimited
+    //    keys the semantic conventions use, so `.http.request.method` is written as a
+    //    nested literal rather than an @"http.request.method" field name.
+    heading("plain body, attributes from a struct literal");
+    const request_attrs = sdk.attributes.flatten(.{
+        .http = .{
+            .request = .{ .method = "GET" },
+            .response = .{ .status_code = 200 },
+        },
+        .url = .{ .path = "/api/users" },
+    });
+    logger.emit(.info, "Request handled", .{ .attributes = &request_attrs });
+
+    // 4. A structured body: the payload of the record is key-value fields instead of
+    //    a message. Values can be computed at runtime.
+    heading("structured body");
+    const users = [_][]const u8{ "alice", "bob", "carol" };
+    logger.emitStructured(.debug, .{
+        .page = 1,
+        .returned = users.len,
+        .truncated = false,
+    }, .{});
+
+    // 5. Both at once, with an event name. Fields covered by the semantic conventions
+    //    belong in the attributes, which backends index; the body carries what is
+    //    specific to this event.
+    //    See https://opentelemetry.io/docs/specs/semconv/general/events/
+    heading("structured body with an event name and attributes");
+    logger.emitStructured(.info, .{
+        .cache = .{ .hit = false, .lookup_ms = 0.4 },
+        .upstream_retries = 2,
+    }, .{
+        .event_name = "app.request.handled",
+        .attributes = &request_attrs,
+    });
+
+    // 6. The attribute list can also be built inline: the temporary lives until the end
+    //    of the statement, which covers the whole emit call.
+    heading("attributes built inline");
+    logger.emitStructured(.err, .{
+        .reason = "connection reset",
+        .attempts = 3,
+    }, .{
+        .event_name = "app.upstream.failed",
+        .attributes = &sdk.attributes.flatten(.{
+            .server = .{ .address = "upstream.example.com", .port = 443 },
+            .error_type = "ConnectionResetError",
+        }),
+    });
+
+    try provider.shutdown();
+}
+
+fn heading(title: []const u8) void {
+    std.debug.print("\n{s}\n", .{title});
+}
+
+/// Prints every field this example cares about: the SDK's StdoutExporter serializes the
+/// body as JSON, but not the attributes or the event name.
+const PrintExporter = struct {
+    writer: *std.Io.Writer,
+
+    const Self = @This();
+
+    /// The writer must remain valid for the lifetime of the exporter.
+    pub fn init(writer: *std.Io.Writer) Self {
+        return Self{ .writer = writer };
+    }
+
+    pub fn exportLogs(ctx: *anyopaque, log_records: []sdk.logs.ReadbleLogRecord) anyerror!void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        for (log_records) |record| {
+            try self.writer.print("  {s}", .{severityName(record.severity_number)});
+            if (record.event_name) |event_name| {
+                try self.writer.print(" event_name={s}", .{event_name});
+            }
+            if (record.body) |body| switch (body) {
+                .string => |message| try self.writer.print(" body=\"{s}\"", .{message}),
+                .structured => |fields| {
+                    try self.writer.writeAll(" body={");
+                    try writeAttributes(self.writer, fields);
+                    try self.writer.writeAll(" }");
+                },
+            };
+            if (record.attributes.len > 0) {
+                try self.writer.writeAll(" attributes={");
+                try writeAttributes(self.writer, record.attributes);
+                try self.writer.writeAll(" }");
+            }
+            try self.writer.writeByte('\n');
+        }
+        try self.writer.flush();
+    }
+
+    pub fn shutdown(_: *anyopaque) anyerror!void {}
+
+    pub fn asLogRecordExporter(self: *Self) sdk.logs.LogRecordExporter {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .exportLogsFn = exportLogs,
+                .shutdownFn = shutdown,
+            },
+        };
+    }
+};
+
+fn writeAttributes(writer: *std.Io.Writer, attributes: []const sdk.attributes.Attribute) !void {
+    for (attributes) |attribute| {
+        try writer.print(" {s}=", .{attribute.key});
+        switch (attribute.value) {
+            .string => |value| try writer.print("\"{s}\"", .{value}),
+            .bool => |value| try writer.print("{}", .{value}),
+            .int => |value| try writer.print("{d}", .{value}),
+            .double => |value| try writer.print("{d}", .{value}),
+            .baggage => try writer.writeAll("<baggage>"),
+        }
+    }
+}
+
+/// Short name for a severity number, following the ranges of the log data model:
+/// https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+fn severityName(severity_number: ?u8) []const u8 {
+    const number = severity_number orelse return "UNSET";
+    return switch (number) {
+        1...4 => "TRACE",
+        5...8 => "DEBUG",
+        9...12 => "INFO",
+        13...16 => "WARN",
+        17...20 => "ERROR",
+        else => "FATAL",
+    };
+}

--- a/opentelemetry-sdk/examples/logs/structured.zig
+++ b/opentelemetry-sdk/examples/logs/structured.zig
@@ -1,8 +1,10 @@
 //! Shows the ways of shaping a log record: a plain string body or a structured one,
-//! with attributes written by hand or derived from a struct literal at compile time.
+//! with attributes written by hand, taken from the semantic conventions, or derived from
+//! a struct literal at compile time.
 
 const std = @import("std");
 const sdk = @import("opentelemetry-sdk");
+const semconv = @import("opentelemetry-semconv");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
@@ -24,28 +26,38 @@ pub fn main(init: std.process.Init) !void {
     heading("plain body");
     logger.emit(.info, "Application started", .{});
 
-    // 2. Attributes written by hand, one Attribute per key.
+    // 2. Attributes written by hand, one Attribute per key. Names covered by the semantic
+    //    conventions come from the semconv module rather than being spelled out here.
     heading("plain body, attributes written by hand");
     const server_attrs = [_]sdk.attributes.Attribute{
-        .{ .key = "server.address", .value = .{ .string = "localhost" } },
-        .{ .key = "server.port", .value = .{ .int = 8080 } },
+        .{ .key = semconv.attribute.server_address.name, .value = .{ .string = "localhost" } },
+        .{ .key = semconv.attribute.server_port.name, .value = .{ .int = 8080 } },
     };
     logger.emit(.info, "Listening for connections", .{ .attributes = &server_attrs });
 
-    // 3. The same list from a struct literal. Nested literals become the dot-delimited
-    //    keys the semantic conventions use, so `.http.request.method` is written as a
-    //    nested literal rather than an @"http.request.method" field name.
-    heading("plain body, attributes from a struct literal");
-    const request_attrs = sdk.attributes.flatten(.{
-        .http = .{
-            .request = .{ .method = "GET" },
-            .response = .{ .status_code = 200 },
-        },
-        .url = .{ .path = "/api/users" },
+    // 3. The same, from key-value pairs. A key can be a semantic convention definition,
+    //    which saves reaching for `.name` (or `.base.name`, for the ones with well-known
+    //    values), and those well-known values can be passed as they are.
+    heading("plain body, attributes from semantic conventions");
+    const request_attrs = sdk.attributes.fromPairs(.{
+        .{ semconv.attribute.http_request_method, semconv.attribute.http_request_methodValue.get },
+        .{ semconv.attribute.http_response_status_code, 200 },
+        .{ semconv.attribute.url_path, "/api/users" },
     });
     logger.emit(.info, "Request handled", .{ .attributes = &request_attrs });
 
-    // 4. A structured body: the payload of the record is key-value fields instead of
+    // 4. Attributes this application owns, from a struct literal: nested literals become
+    //    dot-delimited keys, so a whole namespace is written once.
+    heading("plain body, attributes from a struct literal");
+    const checkout_attrs = sdk.attributes.flatten(.{
+        .checkout = .{
+            .cart = .{ .items = 3, .currency = "EUR" },
+            .coupon = .{ .applied = true },
+        },
+    });
+    logger.emit(.info, "Checkout completed", .{ .attributes = &checkout_attrs });
+
+    // 5. A structured body: the payload of the record is key-value fields instead of
     //    a message. Values can be computed at runtime.
     heading("structured body");
     const users = [_][]const u8{ "alice", "bob", "carol" };
@@ -55,7 +67,7 @@ pub fn main(init: std.process.Init) !void {
         .truncated = false,
     }, .{});
 
-    // 5. Both at once, with an event name. Fields covered by the semantic conventions
+    // 6. Both at once, with an event name. Fields covered by the semantic conventions
     //    belong in the attributes, which backends index; the body carries what is
     //    specific to this event.
     //    See https://opentelemetry.io/docs/specs/semconv/general/events/
@@ -68,7 +80,7 @@ pub fn main(init: std.process.Init) !void {
         .attributes = &request_attrs,
     });
 
-    // 6. The attribute list can also be built inline: the temporary lives until the end
+    // 7. The attribute list can also be built inline: the temporary lives until the end
     //    of the statement, which covers the whole emit call.
     heading("attributes built inline");
     logger.emitStructured(.err, .{
@@ -76,9 +88,10 @@ pub fn main(init: std.process.Init) !void {
         .attempts = 3,
     }, .{
         .event_name = "app.upstream.failed",
-        .attributes = &sdk.attributes.flatten(.{
-            .server = .{ .address = "upstream.example.com", .port = 443 },
-            .error_type = "ConnectionResetError",
+        .attributes = &sdk.attributes.fromPairs(.{
+            .{ semconv.attribute.server_address, "upstream.example.com" },
+            .{ semconv.attribute.server_port, 443 },
+            .{ semconv.attribute.error_type, "ConnectionResetError" },
         }),
     });
 

--- a/opentelemetry-sdk/examples/logs/structured.zig
+++ b/opentelemetry-sdk/examples/logs/structured.zig
@@ -37,10 +37,11 @@ pub fn main(init: std.process.Init) !void {
 
     // 3. The same, from key-value pairs. A key can be a semantic convention definition,
     //    which saves reaching for `.name` (or `.base.name`, for the ones with well-known
-    //    values), and those well-known values can be passed as they are.
+    //    values). A definition that has well-known values also names their enum, so `.get`
+    //    below is enough to mean `semconv.attribute.http_request_methodValue.get`.
     heading("plain body, attributes from semantic conventions");
     const request_attrs = sdk.attributes.fromPairs(.{
-        .{ semconv.attribute.http_request_method, semconv.attribute.http_request_methodValue.get },
+        .{ semconv.attribute.http_request_method, .get },
         .{ semconv.attribute.http_response_status_code, 200 },
         .{ semconv.attribute.url_path, "/api/users" },
     });

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -12,8 +12,8 @@ const SimpleLogRecordProcessor = @import("../../sdk/logs/log_record_processor.zi
 const BatchingLogRecordProcessor = @import("../../sdk/logs/log_record_processor.zig").BatchingLogRecordProcessor;
 const LogRecordProcessor = @import("../../sdk/logs/log_record_processor.zig").LogRecordProcessor;
 const Attribute = @import("../../attributes.zig").Attribute;
-const AttributeValue = @import("../../attributes.zig").AttributeValue;
 const Attributes = @import("../../attributes.zig").Attributes;
+const flattenAttributes = @import("../../attributes.zig").flatten;
 const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
 const context_api = @import("../context/context.zig");
 const Context = context_api.Context;
@@ -303,32 +303,6 @@ pub const LoggerProvider = struct {
     }
 };
 
-fn structFieldToAttributeValue(v: anytype) AttributeValue {
-    const T = @TypeOf(v);
-    return switch (@typeInfo(T)) {
-        .pointer => |p| switch (p.size) {
-            .slice => if (p.child == u8)
-                .{ .string = v }
-            else
-                @compileError("unsupported slice type for structured log field: " ++ @typeName(T)),
-            .one => switch (@typeInfo(p.child)) {
-                .array => |a| if (a.child == u8)
-                    .{ .string = v } // *const [N:0]u8 string literal
-                else
-                    @compileError("unsupported array type for structured log field: " ++ @typeName(T)),
-                else => @compileError("unsupported pointer type for structured log field: " ++ @typeName(T)),
-            },
-            else => @compileError("unsupported pointer type for structured log field: " ++ @typeName(T)),
-        },
-        .bool => .{ .bool = v },
-        .int => .{ .int = @as(i64, v) },
-        .comptime_int => .{ .int = @as(i64, v) },
-        .float => .{ .double = @as(f64, v) },
-        .comptime_float => .{ .double = @as(f64, v) },
-        else => @compileError("unsupported type for structured log field: " ++ @typeName(T)),
-    };
-}
-
 /// Severity level for a log record.
 ///
 /// Simple variants map to the primary sub-level of each OTel severity group:
@@ -431,15 +405,26 @@ pub const Logger = struct {
     }
 
     /// Emit a structured log record whose body is a set of key-value fields.
-    /// `data` must be an anonymous struct literal; each field becomes a structured entry in the body.
+    /// `data` must be an anonymous struct literal; each field becomes a structured entry in the
+    /// body, and nested struct literals are flattened into dot-delimited keys at compile time
+    /// (`.{ .cache = .{ .hit = false } }` becomes the body field `cache.hit`).
     /// Field values must be one of: `[]const u8`, `bool`, an integer, or a float (or comptime equivalents).
+    ///
+    /// The body carries the payload of the event. Anything covered by the semantic conventions
+    /// belongs in `options.attributes` instead, which backends index and which conventions
+    /// require for structured event details: see
+    /// https://opentelemetry.io/docs/specs/semconv/general/events/
+    /// `sdk.attributes.flatten` builds that list from the same kind of struct literal.
     ///
     /// Example:
     /// ```zig
+    /// const attrs = sdk.attributes.flatten(.{
+    ///     .http = .{ .request = .{ .method = "GET" }, .response = .{ .status_code = 200 } },
+    /// });
     /// logger.emitStructured(.info, .{
-    ///     .@"http.method" = "GET",
-    ///     .@"http.status" = 200,
-    /// }, .{ .event_name = "http.request" });
+    ///     .cache = .{ .hit = false, .lookup_ms = 0.4 },
+    ///     .upstream_retries = 2,
+    /// }, .{ .event_name = "app.request.handled", .attributes = &attrs });
     /// ```
     pub fn emitStructured(
         self: *Self,
@@ -449,14 +434,9 @@ pub const Logger = struct {
     ) void {
         if (self.provider.sdk_disabled or self.provider.is_shutdown.load(.acquire)) return;
 
-        const fields = @typeInfo(@TypeOf(data)).@"struct".fields;
-        var body_attrs: [fields.len]Attribute = undefined;
-        inline for (fields, 0..) |field, i| {
-            body_attrs[i] = .{
-                .key = field.name,
-                .value = structFieldToAttributeValue(@field(data, field.name)),
-            };
-        }
+        // Borrowed by the record for the duration of emitRecord, which is the only
+        // window in which processors see it.
+        const body_attrs = flattenAttributes(data);
         self.emitRecord(severity, .{ .structured = &body_attrs }, options);
     }
 
@@ -977,16 +957,18 @@ test "LoggerProvider with config from environment" {
     try std.testing.expectEqual(@as(usize, @intCast(lc.blrp_max_export_batch_size)), batch_processor.max_export_batch_size);
 }
 
-test "Logger.emitStructured produces structured body with correct fields" {
+test "Logger.emitStructured flattens nested body fields and keeps attributes separate" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
     const MockExporter = struct {
         field_count: usize = 0,
-        found_method: bool = false,
-        found_status: bool = false,
-        found_success: bool = false,
-        found_duration: bool = false,
+        found_cache_hit: bool = false,
+        found_lookup_ms: bool = false,
+        found_retries: bool = false,
+        attribute_count: usize = 0,
+        method: ?[]const u8 = null,
+        status: ?i64 = null,
         event_name: ?[]const u8 = null,
 
         pub fn exportLogs(ctx: *anyopaque, records: []ReadableLogRecord) anyerror!void {
@@ -999,14 +981,18 @@ test "Logger.emitStructured produces structured body with correct fields" {
             };
             self.field_count = sb.len;
             for (sb) |attr| {
-                if (std.mem.eql(u8, attr.key, "http.method"))
-                    self.found_method = std.mem.eql(u8, attr.value.string, "GET");
-                if (std.mem.eql(u8, attr.key, "http.status"))
-                    self.found_status = attr.value.int == 200;
-                if (std.mem.eql(u8, attr.key, "http.success"))
-                    self.found_success = attr.value.bool == true;
-                if (std.mem.eql(u8, attr.key, "http.duration_ms"))
-                    self.found_duration = attr.value.double == 12.5;
+                if (std.mem.eql(u8, attr.key, "cache.hit"))
+                    self.found_cache_hit = attr.value.bool == false;
+                if (std.mem.eql(u8, attr.key, "cache.lookup_ms"))
+                    self.found_lookup_ms = attr.value.double == 0.4;
+                if (std.mem.eql(u8, attr.key, "upstream_retries"))
+                    self.found_retries = attr.value.int == 2;
+            }
+            self.attribute_count = records[0].attributes.len;
+            for (records[0].attributes) |attr| {
+                // Both values are string literals in this test, so they outlive the callback.
+                if (std.mem.eql(u8, attr.key, "http.request.method")) self.method = attr.value.string;
+                if (std.mem.eql(u8, attr.key, "http.response.status_code")) self.status = attr.value.int;
             }
         }
 
@@ -1036,17 +1022,37 @@ test "Logger.emitStructured produces structured body with correct fields" {
     const scope = InstrumentationScope{ .name = "test-logger" };
     const logger = try provider.getLogger(scope);
 
+    // Semantic convention fields go in the attributes, the event payload in the body.
+    const attrs = flattenAttributes(.{
+        .http = .{ .request = .{ .method = "GET" }, .response = .{ .status_code = 200 } },
+    });
     logger.emitStructured(.info, .{
-        .@"http.method" = "GET",
-        .@"http.status" = 200,
-        .@"http.success" = true,
-        .@"http.duration_ms" = 12.5,
-    }, .{ .event_name = "http.request" });
+        .cache = .{ .hit = false, .lookup_ms = 0.4 },
+        .upstream_retries = 2,
+    }, .{ .event_name = "app.request.handled", .attributes = &attrs });
 
-    try std.testing.expectEqual(@as(usize, 4), mock_exporter.field_count);
-    try std.testing.expect(mock_exporter.found_method);
-    try std.testing.expect(mock_exporter.found_status);
-    try std.testing.expect(mock_exporter.found_success);
-    try std.testing.expect(mock_exporter.found_duration);
-    try std.testing.expectEqualStrings("http.request", mock_exporter.event_name.?);
+    try std.testing.expectEqual(@as(usize, 3), mock_exporter.field_count);
+    try std.testing.expect(mock_exporter.found_cache_hit);
+    try std.testing.expect(mock_exporter.found_lookup_ms);
+    try std.testing.expect(mock_exporter.found_retries);
+    try std.testing.expectEqual(@as(usize, 2), mock_exporter.attribute_count);
+    try std.testing.expectEqualStrings("GET", mock_exporter.method.?);
+    try std.testing.expectEqual(@as(i64, 200), mock_exporter.status.?);
+    try std.testing.expectEqualStrings("app.request.handled", mock_exporter.event_name.?);
+
+    // The attribute list can also be built inline: the temporary lives until the
+    // enclosing statement ends, which covers the whole synchronous emit.
+    logger.emitStructured(.info, .{
+        .cache = .{ .hit = true, .lookup_ms = 0.1 },
+        .upstream_retries = 0,
+    }, .{
+        .event_name = "app.request.handled",
+        .attributes = &flattenAttributes(.{
+            .http = .{ .request = .{ .method = "POST" }, .response = .{ .status_code = 204 } },
+        }),
+    });
+
+    try std.testing.expectEqual(@as(usize, 2), mock_exporter.attribute_count);
+    try std.testing.expectEqualStrings("POST", mock_exporter.method.?);
+    try std.testing.expectEqual(@as(i64, 204), mock_exporter.status.?);
 }

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -421,7 +421,7 @@ pub const Logger = struct {
     /// Example:
     /// ```zig
     /// const attrs = sdk.attributes.fromPairs(.{
-    ///     .{ semconv.attribute.http_request_method, semconv.attribute.http_request_methodValue.get },
+    ///     .{ semconv.attribute.http_request_method, .get },
     ///     .{ semconv.attribute.http_response_status_code, 200 },
     /// });
     /// logger.emitStructured(.info, .{

--- a/opentelemetry-sdk/src/api/logs/logger_provider.zig
+++ b/opentelemetry-sdk/src/api/logs/logger_provider.zig
@@ -14,6 +14,7 @@ const LogRecordProcessor = @import("../../sdk/logs/log_record_processor.zig").Lo
 const Attribute = @import("../../attributes.zig").Attribute;
 const Attributes = @import("../../attributes.zig").Attributes;
 const flattenAttributes = @import("../../attributes.zig").flatten;
+const attributesFromPairs = @import("../../attributes.zig").fromPairs;
 const InstrumentationScope = @import("../../scope.zig").InstrumentationScope;
 const context_api = @import("../context/context.zig");
 const Context = context_api.Context;
@@ -414,12 +415,14 @@ pub const Logger = struct {
     /// belongs in `options.attributes` instead, which backends index and which conventions
     /// require for structured event details: see
     /// https://opentelemetry.io/docs/specs/semconv/general/events/
-    /// `sdk.attributes.flatten` builds that list from the same kind of struct literal.
+    /// `sdk.attributes.fromPairs` builds that list from convention definitions, and
+    /// `sdk.attributes.flatten` from a struct literal for the attributes an application owns.
     ///
     /// Example:
     /// ```zig
-    /// const attrs = sdk.attributes.flatten(.{
-    ///     .http = .{ .request = .{ .method = "GET" }, .response = .{ .status_code = 200 } },
+    /// const attrs = sdk.attributes.fromPairs(.{
+    ///     .{ semconv.attribute.http_request_method, semconv.attribute.http_request_methodValue.get },
+    ///     .{ semconv.attribute.http_response_status_code, 200 },
     /// });
     /// logger.emitStructured(.info, .{
     ///     .cache = .{ .hit = false, .lookup_ms = 0.4 },
@@ -1023,8 +1026,12 @@ test "Logger.emitStructured flattens nested body fields and keeps attributes sep
     const logger = try provider.getLogger(scope);
 
     // Semantic convention fields go in the attributes, the event payload in the body.
-    const attrs = flattenAttributes(.{
-        .http = .{ .request = .{ .method = "GET" }, .response = .{ .status_code = 200 } },
+    // Their names are spelled out here because the SDK does not depend on the semconv
+    // module; applications pass its definitions to fromPairs instead, as the
+    // examples/logs/structured.zig example does.
+    const attrs = attributesFromPairs(.{
+        .{ "http.request.method", "GET" },
+        .{ "http.response.status_code", 200 },
     });
     logger.emitStructured(.info, .{
         .cache = .{ .hit = false, .lookup_ms = 0.4 },
@@ -1047,8 +1054,9 @@ test "Logger.emitStructured flattens nested body fields and keeps attributes sep
         .upstream_retries = 0,
     }, .{
         .event_name = "app.request.handled",
-        .attributes = &flattenAttributes(.{
-            .http = .{ .request = .{ .method = "POST" }, .response = .{ .status_code = 204 } },
+        .attributes = &attributesFromPairs(.{
+            .{ "http.request.method", "POST" },
+            .{ "http.response.status_code", 204 },
         }),
     });
 

--- a/opentelemetry-sdk/src/attributes.zig
+++ b/opentelemetry-sdk/src/attributes.zig
@@ -123,6 +123,10 @@ pub const Attribute = struct {
     }
 };
 
+/// Builds an attribute list from a struct literal at compile time, see `attributes/flatten.zig`.
+pub const flatten = @import("attributes/flatten.zig").flatten;
+pub const flatCount = @import("attributes/flatten.zig").flatCount;
+
 /// Creates a slice of attributes from a list of key-value pairs.
 /// Caller owns the returned memory and should free the slice when done
 /// through the same allocator.

--- a/opentelemetry-sdk/src/attributes.zig
+++ b/opentelemetry-sdk/src/attributes.zig
@@ -123,9 +123,10 @@ pub const Attribute = struct {
     }
 };
 
-/// Builds an attribute list from a struct literal at compile time, see `attributes/flatten.zig`.
-pub const flatten = @import("attributes/flatten.zig").flatten;
-pub const flatCount = @import("attributes/flatten.zig").flatCount;
+/// Compile-time builders for attribute lists, see `attributes/builders.zig`.
+pub const fromPairs = @import("attributes/builders.zig").fromPairs;
+pub const flatten = @import("attributes/builders.zig").flatten;
+pub const flatCount = @import("attributes/builders.zig").flatCount;
 
 /// Creates a slice of attributes from a list of key-value pairs.
 /// Caller owns the returned memory and should free the slice when done

--- a/opentelemetry-sdk/src/attributes/builders.zig
+++ b/opentelemetry-sdk/src/attributes/builders.zig
@@ -1,18 +1,21 @@
-//! Compile-time conversion of struct literals into attribute lists.
+//! Compile-time builders for attribute lists.
 //!
 //! Signals take attributes as a `[]const Attribute`, which is verbose to write by hand.
-//! `flatten` builds that list from a struct literal instead, turning nested literals into
-//! the dot-delimited keys the semantic conventions use.
+//! `fromPairs` builds that list from key-value pairs, where a key can be a semantic
+//! convention attribute definition, and `flatten` builds it from a struct literal, turning
+//! nested literals into dot-delimited keys.
+//!
+//! Neither allocates: both return a fixed-size array sized at compile time.
 
 const std = @import("std");
 
 const Attribute = @import("../attributes.zig").Attribute;
 const AttributeValue = @import("../attributes.zig").AttributeValue;
 
-/// Converts a struct literal field value into an AttributeValue.
+/// Converts a value into an AttributeValue.
 /// Only the types that an OTel attribute can hold are accepted, anything else is
 /// a compile error at the call site.
-fn fieldToAttributeValue(v: anytype) AttributeValue {
+fn toAttributeValue(v: anytype) AttributeValue {
     const T = @TypeOf(v);
     return switch (@typeInfo(T)) {
         .pointer => |p| switch (p.size) {
@@ -32,8 +35,83 @@ fn fieldToAttributeValue(v: anytype) AttributeValue {
         .bool => .{ .bool = v },
         .int, .comptime_int => .{ .int = @intCast(v) },
         .float, .comptime_float => .{ .double = @floatCast(v) },
+        // Well-known values of a semantic convention enum attribute, which spell their
+        // wire representation through toString().
+        .@"enum" => if (@hasDecl(T, "toString"))
+            .{ .string = v.toString() }
+        else
+            @compileError("enum " ++ @typeName(T) ++ " has no toString() to spell its attribute value"),
         else => @compileError("unsupported type for attribute value: " ++ @typeName(T)),
     };
+}
+
+fn isString(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .pointer => |p| switch (p.size) {
+            .slice => p.child == u8,
+            .one => switch (@typeInfo(p.child)) {
+                .array => |a| a.child == u8,
+                else => false,
+            },
+            else => false,
+        },
+        else => false,
+    };
+}
+
+/// The key of an attribute, either spelled out or taken from a semantic convention
+/// attribute definition of the opentelemetry-semconv module. Definitions are matched
+/// structurally, so the SDK does not depend on that module: a plain `name` field is a
+/// `types.Attribute`, a `base.name` one is a `types.EnumAttribute`.
+fn keyOf(definition: anytype) []const u8 {
+    const T = @TypeOf(definition);
+    if (comptime isString(T)) return definition;
+    if (comptime @typeInfo(T) == .@"struct") {
+        if (comptime @hasField(T, "name")) return definition.name;
+        if (comptime @hasField(T, "base")) return definition.base.name;
+    }
+    @compileError("attribute key must be a string or a semantic convention attribute definition, found " ++ @typeName(T));
+}
+
+fn pairFields(comptime T: type) []const std.builtin.Type.StructField {
+    const info = @typeInfo(T);
+    if (info != .@"struct" or !info.@"struct".is_tuple) {
+        @compileError("expected a tuple of .{ key, value } pairs, found " ++ @typeName(T));
+    }
+    inline for (info.@"struct".fields) |field| {
+        const pair = @typeInfo(field.type);
+        if (pair != .@"struct" or !pair.@"struct".is_tuple or pair.@"struct".fields.len != 2) {
+            @compileError("expected a .{ key, value } pair, found " ++ @typeName(field.type));
+        }
+    }
+    return info.@"struct".fields;
+}
+
+/// Builds an attribute list from `.{ key, value }` pairs, without allocating.
+///
+/// A key is either a string or an attribute definition from the opentelemetry-semconv
+/// module, which keeps convention names out of the call site:
+/// ```zig
+/// const attrs = fromPairs(.{
+///     .{ semconv.attribute.http_request_method, semconv.attribute.http_request_methodValue.get },
+///     .{ semconv.attribute.http_response_status_code, 200 },
+///     .{ "acme.tenant.id", tenant_id },
+/// });
+/// ```
+/// Values must be a `[]const u8`, a `bool`, an integer, a float, or an enum spelling its
+/// value through `toString()`, which is how semantic convention enum values are written.
+///
+/// Keys taken from a definition and string values are borrowed, not copied. The returned
+/// array is owned by the caller and must outlive every use of the attributes it holds.
+/// Taking its address inline, as in `.attributes = &fromPairs(.{ ... })`, is enough for a
+/// call that consumes the attributes before it returns.
+pub fn fromPairs(pairs: anytype) [pairFields(@TypeOf(pairs)).len]Attribute {
+    var attrs: [pairFields(@TypeOf(pairs)).len]Attribute = undefined;
+    inline for (comptime pairFields(@TypeOf(pairs)), 0..) |field, i| {
+        const pair = @field(pairs, field.name);
+        attrs[i] = .{ .key = keyOf(pair[0]), .value = toAttributeValue(pair[1]) };
+    }
+    return attrs;
 }
 
 /// Whether `T` is a struct with named fields, the shape `flatten` walks into.
@@ -71,7 +149,7 @@ fn flattenInto(comptime prefix: []const u8, data: anytype, out: []Attribute, nex
         if (comptime isNamedStruct(@TypeOf(value))) {
             flattenInto(key, value, out, next);
         } else {
-            out[next.*] = .{ .key = key, .value = fieldToAttributeValue(value) };
+            out[next.*] = .{ .key = key, .value = toAttributeValue(value) };
             next.* += 1;
         }
     }
@@ -79,14 +157,15 @@ fn flattenInto(comptime prefix: []const u8, data: anytype, out: []Attribute, nex
 
 /// Builds an attribute list from a struct literal, without allocating.
 ///
-/// Nested struct literals are flattened into dot-delimited keys at compile time, which
-/// is the naming style the semantic conventions use:
+/// Nested struct literals are flattened into dot-delimited keys at compile time:
 /// ```zig
-/// const attrs = flatten(.{
-///     .http = .{ .request = .{ .method = "GET" }, .response = .{ .status_code = 200 } },
-/// });
-/// // { "http.request.method" = "GET", "http.response.status_code" = 200 }
+/// const attrs = flatten(.{ .checkout = .{ .cart = .{ .items = 3 }, .coupon = true } });
+/// // { "checkout.cart.items" = 3, "checkout.coupon" = true }
 /// ```
+/// Keys are spelled at the call site, so this is for the attributes an application owns.
+/// Names covered by the semantic conventions should come from the opentelemetry-semconv
+/// module instead of being written out here: pass the definitions to `fromPairs`.
+///
 /// Field values must be a `[]const u8`, a `bool`, an integer or a float; anything else is
 /// a compile error. Note that map-valued attributes, which the specification allows, are
 /// not representable by `AttributeValue`, and the semantic conventions recommend flat
@@ -104,24 +183,87 @@ pub fn flatten(data: anytype) [flatCount(@TypeOf(data))]Attribute {
     return attrs;
 }
 
+test "fromPairs takes the key from a semantic convention definition" {
+    // Shape of the opentelemetry-semconv types: a plain definition carries the name
+    // directly, an enum one carries it in `base`, and its values spell themselves.
+    const Definition = struct { name: []const u8, stability: enum { stable } };
+    const Method = enum {
+        get,
+        pub fn toString(self: @This()) []const u8 {
+            return switch (self) {
+                .get => "GET",
+            };
+        }
+    };
+    const EnumDefinition = struct { base: Definition, well_known_values: Method };
+
+    const http_request_method: EnumDefinition = .{
+        .base = .{ .name = "http.request.method", .stability = .stable },
+        .well_known_values = .get,
+    };
+    const http_response_status_code: Definition = .{ .name = "http.response.status_code", .stability = .stable };
+
+    const attrs = fromPairs(.{
+        .{ http_request_method, Method.get },
+        .{ http_response_status_code, 200 },
+        .{ "acme.tenant.id", "t-42" },
+    });
+
+    try std.testing.expectEqual(@as(usize, 3), attrs.len);
+    try std.testing.expectEqualStrings("http.request.method", attrs[0].key);
+    try std.testing.expectEqualStrings("GET", attrs[0].value.string);
+    try std.testing.expectEqualStrings("http.response.status_code", attrs[1].key);
+    try std.testing.expectEqual(@as(i64, 200), attrs[1].value.int);
+    try std.testing.expectEqualStrings("acme.tenant.id", attrs[2].key);
+    try std.testing.expectEqualStrings("t-42", attrs[2].value.string);
+
+    // The result coerces to the slice type the signals take.
+    const slice: []const Attribute = &attrs;
+    try std.testing.expectEqual(@as(usize, 3), slice.len);
+}
+
+test "fromPairs accepts runtime values" {
+    var status: u16 = 0;
+    status = 503;
+    const reason: []const u8 = "upstream timeout";
+    const ratio: f32 = 0.5;
+
+    const attrs = fromPairs(.{
+        .{ "http.response.status_code", status },
+        .{ "error.message", reason },
+        .{ "sampling.ratio", ratio },
+        .{ "retried", true },
+    });
+
+    try std.testing.expectEqual(@as(i64, 503), attrs[0].value.int);
+    try std.testing.expectEqualStrings("upstream timeout", attrs[1].value.string);
+    try std.testing.expectEqual(@as(f64, 0.5), attrs[2].value.double);
+    try std.testing.expectEqual(true, attrs[3].value.bool);
+}
+
+test "fromPairs of no pairs is empty" {
+    const attrs = fromPairs(.{});
+    try std.testing.expectEqual(@as(usize, 0), attrs.len);
+}
+
 test "flatten nests struct literals into dot-delimited keys" {
     const attrs = flatten(.{
-        .http = .{
-            .request = .{ .method = "GET" },
-            .response = .{ .status_code = 200 },
+        .checkout = .{
+            .cart = .{ .items = 3 },
+            .coupon = .{ .applied = true },
         },
-        .server = .{ .address = "example.com" },
+        .experiment = .{ .variant = "b" },
         .duration_ms = 12.5,
         .cached = true,
     });
 
     try std.testing.expectEqual(@as(usize, 5), attrs.len);
-    try std.testing.expectEqualStrings("http.request.method", attrs[0].key);
-    try std.testing.expectEqualStrings("GET", attrs[0].value.string);
-    try std.testing.expectEqualStrings("http.response.status_code", attrs[1].key);
-    try std.testing.expectEqual(@as(i64, 200), attrs[1].value.int);
-    try std.testing.expectEqualStrings("server.address", attrs[2].key);
-    try std.testing.expectEqualStrings("example.com", attrs[2].value.string);
+    try std.testing.expectEqualStrings("checkout.cart.items", attrs[0].key);
+    try std.testing.expectEqual(@as(i64, 3), attrs[0].value.int);
+    try std.testing.expectEqualStrings("checkout.coupon.applied", attrs[1].key);
+    try std.testing.expectEqual(true, attrs[1].value.bool);
+    try std.testing.expectEqualStrings("experiment.variant", attrs[2].key);
+    try std.testing.expectEqualStrings("b", attrs[2].value.string);
     try std.testing.expectEqualStrings("duration_ms", attrs[3].key);
     try std.testing.expectEqual(@as(f64, 12.5), attrs[3].value.double);
     try std.testing.expectEqualStrings("cached", attrs[4].key);

--- a/opentelemetry-sdk/src/attributes/builders.zig
+++ b/opentelemetry-sdk/src/attributes/builders.zig
@@ -41,6 +41,8 @@ fn toAttributeValue(v: anytype) AttributeValue {
             .{ .string = v.toString() }
         else
             @compileError("enum " ++ @typeName(T) ++ " has no toString() to spell its attribute value"),
+        // Reached from `flatten`, where nothing names the enum a literal belongs to.
+        .enum_literal => @compileError("an enum literal does not name its enum: pass it to fromPairs keyed by a semantic convention enum attribute definition, or spell the value out"),
         else => @compileError("unsupported type for attribute value: " ++ @typeName(T)),
     };
 }
@@ -73,6 +75,27 @@ fn keyOf(definition: anytype) []const u8 {
     @compileError("attribute key must be a string or a semantic convention attribute definition, found " ++ @typeName(T));
 }
 
+/// The enum a semantic convention enum attribute definition draws its well-known values
+/// from, or null for any other kind of key. Matched structurally like `keyOf`, on the
+/// `well_known_values` field of `types.EnumAttribute`.
+fn wellKnownEnum(comptime T: type) ?type {
+    if (@typeInfo(T) != .@"struct" or !@hasField(T, "well_known_values")) return null;
+    const E = @FieldType(T, "well_known_values");
+    return if (@typeInfo(E) == .@"enum") E else null;
+}
+
+/// The value of a pair. A bare enum literal is resolved against the enum of the key's
+/// definition, so that `.{ semconv.attribute.http_request_method, .get }` says as much as
+/// naming the value type in full; anything else converts on its own.
+fn valueOf(definition: anytype, value: anytype) AttributeValue {
+    if (comptime @typeInfo(@TypeOf(value)) == .enum_literal) {
+        const E = comptime wellKnownEnum(@TypeOf(definition)) orelse
+            @compileError("an enum literal needs a semantic convention enum attribute definition as its key to name its enum, found " ++ @typeName(@TypeOf(definition)));
+        return toAttributeValue(@as(E, value));
+    }
+    return toAttributeValue(value);
+}
+
 fn pairFields(comptime T: type) []const std.builtin.Type.StructField {
     const info = @typeInfo(T);
     if (info != .@"struct" or !info.@"struct".is_tuple) {
@@ -93,13 +116,18 @@ fn pairFields(comptime T: type) []const std.builtin.Type.StructField {
 /// module, which keeps convention names out of the call site:
 /// ```zig
 /// const attrs = fromPairs(.{
-///     .{ semconv.attribute.http_request_method, semconv.attribute.http_request_methodValue.get },
+///     .{ semconv.attribute.http_request_method, .get },
 ///     .{ semconv.attribute.http_response_status_code, 200 },
 ///     .{ "acme.tenant.id", tenant_id },
 /// });
 /// ```
 /// Values must be a `[]const u8`, a `bool`, an integer, a float, or an enum spelling its
 /// value through `toString()`, which is how semantic convention enum values are written.
+///
+/// A key that defines well-known values also names their enum, so those values can be
+/// written as bare enum literals: `.get` above stands for
+/// `semconv.attribute.http_request_methodValue.get`. A value outside the set is a compile
+/// error, but a plain string is still accepted, for the conventions whose set is open.
 ///
 /// Keys taken from a definition and string values are borrowed, not copied. The returned
 /// array is owned by the caller and must outlive every use of the attributes it holds.
@@ -109,7 +137,7 @@ pub fn fromPairs(pairs: anytype) [pairFields(@TypeOf(pairs)).len]Attribute {
     var attrs: [pairFields(@TypeOf(pairs)).len]Attribute = undefined;
     inline for (comptime pairFields(@TypeOf(pairs)), 0..) |field, i| {
         const pair = @field(pairs, field.name);
-        attrs[i] = .{ .key = keyOf(pair[0]), .value = toAttributeValue(pair[1]) };
+        attrs[i] = .{ .key = keyOf(pair[0]), .value = valueOf(pair[0], pair[1]) };
     }
     return attrs;
 }
@@ -189,9 +217,11 @@ test "fromPairs takes the key from a semantic convention definition" {
     const Definition = struct { name: []const u8, stability: enum { stable } };
     const Method = enum {
         get,
+        post,
         pub fn toString(self: @This()) []const u8 {
             return switch (self) {
                 .get => "GET",
+                .post => "POST",
             };
         }
     };
@@ -220,6 +250,48 @@ test "fromPairs takes the key from a semantic convention definition" {
     // The result coerces to the slice type the signals take.
     const slice: []const Attribute = &attrs;
     try std.testing.expectEqual(@as(usize, 3), slice.len);
+}
+
+test "fromPairs resolves an enum literal against the enum of its key" {
+    const Method = enum {
+        get,
+        post,
+        pub fn toString(self: @This()) []const u8 {
+            return switch (self) {
+                .get => "GET",
+                .post => "POST",
+            };
+        }
+    };
+    const Definition = struct { name: []const u8 };
+    const EnumDefinition = struct { base: Definition, well_known_values: Method };
+
+    const http_request_method: EnumDefinition = .{
+        .base = .{ .name = "http.request.method" },
+        .well_known_values = .get,
+    };
+    // An open set: the definition has well-known values, but any string is allowed.
+    const error_type: EnumDefinition = .{
+        .base = .{ .name = "error.type" },
+        .well_known_values = .get,
+    };
+
+    // A literal is comptime-only, which makes it a comptime field of the pairs tuple;
+    // runtime values in the other pairs are unaffected.
+    var tenant: []const u8 = "";
+    tenant = "t-42";
+
+    const attrs = fromPairs(.{
+        .{ http_request_method, .post },
+        .{ error_type, "ConnectionResetError" },
+        .{ "acme.tenant.id", tenant },
+    });
+
+    try std.testing.expectEqualStrings("http.request.method", attrs[0].key);
+    try std.testing.expectEqualStrings("POST", attrs[0].value.string);
+    try std.testing.expectEqualStrings("error.type", attrs[1].key);
+    try std.testing.expectEqualStrings("ConnectionResetError", attrs[1].value.string);
+    try std.testing.expectEqualStrings("t-42", attrs[2].value.string);
 }
 
 test "fromPairs accepts runtime values" {

--- a/opentelemetry-sdk/src/attributes/builders.zig
+++ b/opentelemetry-sdk/src/attributes/builders.zig
@@ -1,0 +1,159 @@
+//! Compile-time conversion of struct literals into attribute lists.
+//!
+//! Signals take attributes as a `[]const Attribute`, which is verbose to write by hand.
+//! `flatten` builds that list from a struct literal instead, turning nested literals into
+//! the dot-delimited keys the semantic conventions use.
+
+const std = @import("std");
+
+const Attribute = @import("../attributes.zig").Attribute;
+const AttributeValue = @import("../attributes.zig").AttributeValue;
+
+/// Converts a struct literal field value into an AttributeValue.
+/// Only the types that an OTel attribute can hold are accepted, anything else is
+/// a compile error at the call site.
+fn fieldToAttributeValue(v: anytype) AttributeValue {
+    const T = @TypeOf(v);
+    return switch (@typeInfo(T)) {
+        .pointer => |p| switch (p.size) {
+            .slice => if (p.child == u8)
+                .{ .string = v }
+            else
+                @compileError("unsupported slice type for attribute value: " ++ @typeName(T)),
+            .one => switch (@typeInfo(p.child)) {
+                .array => |a| if (a.child == u8)
+                    .{ .string = v } // *const [N:0]u8 string literal
+                else
+                    @compileError("unsupported array type for attribute value: " ++ @typeName(T)),
+                else => @compileError("unsupported pointer type for attribute value: " ++ @typeName(T)),
+            },
+            else => @compileError("unsupported pointer type for attribute value: " ++ @typeName(T)),
+        },
+        .bool => .{ .bool = v },
+        .int, .comptime_int => .{ .int = @intCast(v) },
+        .float, .comptime_float => .{ .double = @floatCast(v) },
+        else => @compileError("unsupported type for attribute value: " ++ @typeName(T)),
+    };
+}
+
+/// Whether `T` is a struct with named fields, the shape `flatten` walks into.
+/// Tuples with fields are not: their field names are "0", "1", ... which would make
+/// meaningless attribute keys. `.{}` is both an empty struct and an empty tuple, so
+/// an empty tuple counts here and yields no attributes.
+fn isNamedStruct(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .@"struct" => |s| !s.is_tuple or s.fields.len == 0,
+        else => false,
+    };
+}
+
+fn namedFields(comptime T: type) []const std.builtin.Type.StructField {
+    if (comptime !isNamedStruct(T)) {
+        @compileError("expected a struct literal with named fields, found " ++ @typeName(T));
+    }
+    return @typeInfo(T).@"struct".fields;
+}
+
+/// Number of attributes `flatten` produces for the struct type `T`: one per leaf
+/// field, counting nested structs recursively.
+pub fn flatCount(comptime T: type) usize {
+    comptime var count: usize = 0;
+    inline for (comptime namedFields(T)) |field| {
+        count += if (comptime isNamedStruct(field.type)) flatCount(field.type) else 1;
+    }
+    return count;
+}
+
+fn flattenInto(comptime prefix: []const u8, data: anytype, out: []Attribute, next: *usize) void {
+    inline for (comptime namedFields(@TypeOf(data))) |field| {
+        const key = comptime if (prefix.len == 0) field.name else prefix ++ "." ++ field.name;
+        const value = @field(data, field.name);
+        if (comptime isNamedStruct(@TypeOf(value))) {
+            flattenInto(key, value, out, next);
+        } else {
+            out[next.*] = .{ .key = key, .value = fieldToAttributeValue(value) };
+            next.* += 1;
+        }
+    }
+}
+
+/// Builds an attribute list from a struct literal, without allocating.
+///
+/// Nested struct literals are flattened into dot-delimited keys at compile time, which
+/// is the naming style the semantic conventions use:
+/// ```zig
+/// const attrs = flatten(.{
+///     .http = .{ .request = .{ .method = "GET" }, .response = .{ .status_code = 200 } },
+/// });
+/// // { "http.request.method" = "GET", "http.response.status_code" = 200 }
+/// ```
+/// Field values must be a `[]const u8`, a `bool`, an integer or a float; anything else is
+/// a compile error. Note that map-valued attributes, which the specification allows, are
+/// not representable by `AttributeValue`, and the semantic conventions recommend flat
+/// attributes anyway: see https://opentelemetry.io/docs/specs/semconv/general/naming/
+///
+/// Keys are compile-time strings and live for the whole program, string values are
+/// borrowed from `data` and not copied. The returned array is owned by the caller and
+/// must outlive every use of the attributes it holds. Taking its address inline, as in
+/// `.attributes = &flatten(.{ ... })`, is enough for a call that consumes the attributes
+/// before it returns.
+pub fn flatten(data: anytype) [flatCount(@TypeOf(data))]Attribute {
+    var attrs: [flatCount(@TypeOf(data))]Attribute = undefined;
+    var next: usize = 0;
+    flattenInto("", data, &attrs, &next);
+    return attrs;
+}
+
+test "flatten nests struct literals into dot-delimited keys" {
+    const attrs = flatten(.{
+        .http = .{
+            .request = .{ .method = "GET" },
+            .response = .{ .status_code = 200 },
+        },
+        .server = .{ .address = "example.com" },
+        .duration_ms = 12.5,
+        .cached = true,
+    });
+
+    try std.testing.expectEqual(@as(usize, 5), attrs.len);
+    try std.testing.expectEqualStrings("http.request.method", attrs[0].key);
+    try std.testing.expectEqualStrings("GET", attrs[0].value.string);
+    try std.testing.expectEqualStrings("http.response.status_code", attrs[1].key);
+    try std.testing.expectEqual(@as(i64, 200), attrs[1].value.int);
+    try std.testing.expectEqualStrings("server.address", attrs[2].key);
+    try std.testing.expectEqualStrings("example.com", attrs[2].value.string);
+    try std.testing.expectEqualStrings("duration_ms", attrs[3].key);
+    try std.testing.expectEqual(@as(f64, 12.5), attrs[3].value.double);
+    try std.testing.expectEqualStrings("cached", attrs[4].key);
+    try std.testing.expectEqual(true, attrs[4].value.bool);
+
+    // The result coerces to the slice type the signals take.
+    const slice: []const Attribute = &attrs;
+    try std.testing.expectEqual(@as(usize, 5), slice.len);
+}
+
+test "flatten accepts runtime values" {
+    const items = [_]u8{ 1, 2, 3 };
+    var status: u16 = 0;
+    status = 503;
+    const reason: []const u8 = "upstream timeout";
+    const ratio: f32 = 0.5;
+
+    const attrs = flatten(.{
+        .count = items.len, // usize
+        .status = status,
+        .reason = reason,
+        .ratio = ratio,
+    });
+
+    try std.testing.expectEqual(@as(i64, 3), attrs[0].value.int);
+    try std.testing.expectEqual(@as(i64, 503), attrs[1].value.int);
+    try std.testing.expectEqualStrings("upstream timeout", attrs[2].value.string);
+    try std.testing.expectEqual(@as(f64, 0.5), attrs[3].value.double);
+}
+
+test "flatten of an empty struct literal is empty" {
+    const attrs = flatten(.{});
+    try std.testing.expectEqual(@as(usize, 0), attrs.len);
+    try std.testing.expectEqual(@as(usize, 0), flatCount(@TypeOf(.{})));
+}

--- a/opentelemetry-sdk/src/sdk.zig
+++ b/opentelemetry-sdk/src/sdk.zig
@@ -8,7 +8,7 @@ test {
     _ = @import("sdk/propagation.zig");
     // helpers
     _ = @import("attributes.zig");
-    _ = @import("attributes/flatten.zig");
+    _ = @import("attributes/builders.zig");
     _ = @import("scope.zig");
     _ = @import("otlp.zig");
 }

--- a/opentelemetry-sdk/src/sdk.zig
+++ b/opentelemetry-sdk/src/sdk.zig
@@ -8,6 +8,7 @@ test {
     _ = @import("sdk/propagation.zig");
     // helpers
     _ = @import("attributes.zig");
+    _ = @import("attributes/flatten.zig");
     _ = @import("scope.zig");
     _ = @import("otlp.zig");
 }


### PR DESCRIPTION
This is an experiment where I tried to go as far as possible with `comptime` syntactic sugar for building attributes lists, and I am looking for feedback on what is useful and what is too much.

## 0. Current state

Before this PR, attributes list can be built manually, with both arbitrary strings as keys and using semconv:
```zig
const attrs = [_]sdk.attributes.Attribute{
    .{ .key = "foo.bar", .value = .{ .string = "baz" } },
    .{ .key = semconv.attribute.server_address.name, .value = .{ .string = "localhost" } },
    .{ .key = semconv.attribute.server_port.name, .value = .{ .int = 8080 } },
    .{
        .key = semconv.attribute.http_request_method.base.name,
        .value = .{ .string = semconv.attribute.http_request_methodValue.get.toString() },
    },
};
```

Note that, in the case of semconv keys, there is nothing in place enforcing that the right type of value is used, and one can mistakenly set the request method to `123` or `"foo"` without the compiler catching it.

Also note how certain keys are `[...].name` while others are `[...].base.name`

## 1. `sdk.attributes.fromPairs`

This builder tries to have the same capabilities, but with sugar to reduce the verbosity:
```zig
const attrs = sdk.attributes.fromPairs(.{
    .{ "foo.bar", "baz" },
    .{ semconv.attribute.server_address, "localhost" },
    .{ semconv.attribute.server_port, 8080 },
    .{ semconv.attribute.http_request_method, .get },
});
```

In this case, it is possible to check the type of the value against the expected type the key declares.
It is NOT done today because the semconv module currently only declares `StringAttributes` and `EnumAttributes` (meaning `server_port` is currently declared as expecting string). But once that gap is addressed we can add the type checks.

## 2. `sdk.attributes.flatten`

Its main use is for the structured log body (`emitStructured`), but it is also usable to build attributes lists by hand.

It takes an anonymous struct and evaluates as a list of Attributes, just like above:

```zig
const checkout_attrs = sdk.attributes.flatten(.{
    .checkout = .{
        .cart = .{ .items = 3, .currency = "EUR" },
        .coupon = .{ .applied = true },
    },
});
```
It will NOT store & transmit attributes as nested struct (technically allowed by the spec), but instead collapse keys by joining section names with `.`: `"checkout.cart.items"`, `"checkout.cart.currency"` and `"checkout.coupon.applied"`

It is done at `comptime` so all resulting strings are static, no allocation is introduced.
Moreover static arrays are concatenable, so `fromPairs` and `flatten` can easily be combined into a single attributes list using `++`.

--------

This PR description was written by hand. The code changes were made with the assistance of an LLM.