### PR TITLE
Add an assignment iterator

### DIFF
--- a/opentelemetry-sdk/src/sdk.zig
+++ b/opentelemetry-sdk/src/sdk.zig
@@ -6,6 +6,7 @@ test {
     _ = @import("sdk/config.zig");
     _ = @import("sdk/resource.zig");
     _ = @import("sdk/propagation.zig");
+    _ = @import("sdk/attribute_list.zig");
     // helpers
     _ = @import("attributes.zig");
     _ = @import("scope.zig");

--- a/opentelemetry-sdk/src/sdk/attribute_list.zig
+++ b/opentelemetry-sdk/src/sdk/attribute_list.zig
@@ -1,0 +1,146 @@
+const std = @import("std");
+
+/// Iterator over `name<assignator>value` pairs joined by `separator`,
+/// e.g. `key1=value1,key2=value2` for `Iterator(',', '=')`.
+///
+/// Names and values are trimmed of surrounding ASCII whitespace. Blank entries
+/// are skipped, but malformed ones are still reported so that callers can warn
+/// about them: an entry with no assignator yields a null `value`, and an entry
+/// such as `=orphan` yields an empty `name`.
+///
+/// The *first* assignator separates the name from the value, so a value may
+/// contain further assignators (`a=b=c` yields `a` / `b=c`).
+///
+/// The iterator borrows the buffer passed to `init`; the returned slices point
+/// into it and are valid for as long as it is.
+pub fn Iterator(comptime separator: u8, comptime assignator: u8) type {
+    return struct {
+        // tokenizeScalar (rather than splitScalar) already skips empty entries,
+        // which covers `a=b,,c=d` and a trailing separator.
+        iterator: std.mem.TokenIterator(u8, .scalar),
+
+        const Self = @This();
+
+        /// A single `name<assignator>value` pair.
+        pub const Entry = struct {
+            name: []const u8,
+            /// Null when the entry carries no assignator at all, as opposed to
+            /// an empty slice for an entry such as `name=`.
+            value: ?[]const u8,
+        };
+
+        pub fn init(buffer: []const u8) Self {
+            return .{ .iterator = std.mem.tokenizeScalar(u8, buffer, separator) };
+        }
+
+        /// Returns the next entry, or null once the buffer is exhausted.
+        pub fn next(self: *Self) ?Entry {
+            while (self.iterator.next()) |assignation| {
+                const entry = trim(assignation);
+                // A whitespace-only entry has nothing worth reporting.
+                if (entry.len == 0) continue;
+
+                const index = std.mem.indexOfScalar(u8, entry, assignator) orelse {
+                    return .{ .name = entry, .value = null };
+                };
+                return .{ .name = trim(entry[0..index]), .value = trim(entry[index + 1 ..]) };
+            }
+            return null;
+        }
+
+        /// Rewinds the iterator to the start of the buffer.
+        pub fn reset(self: *Self) void {
+            self.iterator.reset();
+        }
+
+        fn trim(slice: []const u8) []const u8 {
+            return std.mem.trim(u8, slice, &std.ascii.whitespace);
+        }
+    };
+}
+
+/// Iterator over OTel attribute lists such as the value of
+/// `OTEL_RESOURCE_ATTRIBUTES`: `key1=value1,key2=value2`.
+pub const AttributeListIterator = Iterator(',', '=');
+
+fn expectEntry(
+    expected_name: []const u8,
+    expected_value: ?[]const u8,
+    actual: ?AttributeListIterator.Entry,
+) !void {
+    const entry = actual orelse return error.TestExpectedEntry;
+    try std.testing.expectEqualStrings(expected_name, entry.name);
+    if (expected_value) |expected| {
+        try std.testing.expectEqualStrings(expected, entry.value orelse return error.TestExpectedValue);
+    } else {
+        try std.testing.expectEqual(null, entry.value);
+    }
+}
+
+test AttributeListIterator {
+    const env_var = "foo=bar,bar=baz,,toto=tata,";
+
+    var it: AttributeListIterator = .init(env_var);
+    try expectEntry("foo", "bar", it.next());
+    try expectEntry("bar", "baz", it.next());
+    try expectEntry("toto", "tata", it.next());
+    try std.testing.expectEqual(null, it.next());
+    // Exhaustion is sticky.
+    try std.testing.expectEqual(null, it.next());
+}
+
+test "values may be empty or contain the assignator" {
+    var it: AttributeListIterator = .init("empty=,equation=a=b+c");
+
+    try expectEntry("empty", "", it.next());
+    try expectEntry("equation", "a=b+c", it.next());
+    try std.testing.expectEqual(null, it.next());
+}
+
+test "iterating to exhaustion" {
+    var it: AttributeListIterator = .init("a=1,b=2,c=3");
+
+    var count: usize = 0;
+    while (it.next()) |entry| : (count += 1) {
+        try std.testing.expectEqual(1, entry.name.len);
+        try std.testing.expectEqual(1, (entry.value orelse return error.TestExpectedValue).len);
+    }
+    try std.testing.expectEqual(3, count);
+}
+
+test "surrounding whitespace is trimmed" {
+    var it: AttributeListIterator = .init(" foo = bar ,\tbar\t=\tbaz\t,  novalue  ");
+
+    try expectEntry("foo", "bar", it.next());
+    try expectEntry("bar", "baz", it.next());
+    try expectEntry("novalue", null, it.next());
+    try std.testing.expectEqual(null, it.next());
+}
+
+test "malformed entries are reported, not skipped" {
+    var it: AttributeListIterator = .init("novalue,=orphan,foo=bar");
+
+    // A missing assignator is distinguishable from an empty value.
+    try expectEntry("novalue", null, it.next());
+    try expectEntry("", "orphan", it.next());
+    // Iteration carries on past them.
+    try expectEntry("foo", "bar", it.next());
+    try std.testing.expectEqual(null, it.next());
+}
+
+test "blank input yields nothing" {
+    for ([_][]const u8{ "", ",", " , ", " ,\t,\n" }) |input| {
+        var it: AttributeListIterator = .init(input);
+        try std.testing.expectEqual(null, it.next());
+    }
+}
+
+test "reset rewinds the iterator" {
+    var it: AttributeListIterator = .init("foo=bar,bar=baz");
+
+    while (it.next()) |_| {}
+    try std.testing.expectEqual(null, it.next());
+
+    it.reset();
+    try expectEntry("foo", "bar", it.next());
+}

--- a/opentelemetry-sdk/src/sdk/config.zig
+++ b/opentelemetry-sdk/src/sdk/config.zig
@@ -8,6 +8,8 @@
 
 const std = @import("std");
 
+const AttributeListIterator = @import("attribute_list.zig").AttributeListIterator;
+
 const EnvMap = std.process.Environ.Map;
 
 /// Log level for SDK internal logging
@@ -372,13 +374,11 @@ fn resolveServiceName(allocator: std.mem.Allocator, io: std.Io, env_map: *const 
 
 /// Extract the service.name value from OTEL_RESOURCE_ATTRIBUTES, if present.
 fn serviceNameFromResourceAttributes(attrs: []const u8) ?[]const u8 {
-    var iter = std.mem.splitScalar(u8, attrs, ',');
-    while (iter.next()) |keyVal| {
-        const eq_pos = std.mem.indexOfScalar(u8, keyVal, '=') orelse continue;
-        const key = std.mem.trim(u8, keyVal[0..eq_pos], &std.ascii.whitespace);
-        if (std.mem.eql(u8, key, "service.name")) {
-            return std.mem.trim(u8, keyVal[eq_pos + 1 ..], &std.ascii.whitespace);
-        }
+    var iter: AttributeListIterator = .init(attrs);
+    while (iter.next()) |entry| {
+        if (!std.mem.eql(u8, entry.name, "service.name")) continue;
+        // A bare `service.name` with no value does not count; keep looking.
+        if (entry.value) |value| return value;
     }
     return null;
 }

--- a/opentelemetry-sdk/src/sdk/resource.zig
+++ b/opentelemetry-sdk/src/sdk/resource.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Attribute = @import("../attributes.zig").Attribute;
 const AttributeValue = @import("../attributes.zig").AttributeValue;
 const Configuration = @import("config.zig").Configuration;
+const AttributeListIterator = @import("attribute_list.zig").AttributeListIterator;
 
 /// Build resource attributes from configuration
 /// Combines OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
@@ -46,40 +47,27 @@ fn parseResourceAttributes(
     attributes: *std.ArrayList(Attribute),
     skip_service_name: bool,
 ) !void {
-    var iter = std.mem.splitScalar(u8, attrs_str, ',');
-    while (iter.next()) |pair| {
-        const trimmed = std.mem.trim(u8, pair, &std.ascii.whitespace);
-        if (trimmed.len == 0) continue;
-
-        // Split on '=' to get key and value
-        const eq_pos = std.mem.indexOf(u8, trimmed, "=") orelse {
-            std.log.warn("Invalid resource attribute (missing '='): {s}", .{trimmed});
+    var iter: AttributeListIterator = .init(attrs_str);
+    while (iter.next()) |entry| {
+        const value = entry.value orelse {
+            std.log.warn("Invalid resource attribute (missing '='): {s}", .{entry.name});
             continue;
         };
 
-        const key_part = std.mem.trim(u8, trimmed[0..eq_pos], &std.ascii.whitespace);
-        const value_part = std.mem.trim(u8, trimmed[eq_pos + 1 ..], &std.ascii.whitespace);
-
-        if (key_part.len == 0) {
-            std.log.warn("Invalid resource attribute (empty key): {s}", .{trimmed});
+        if (entry.name.len == 0) {
+            std.log.warn("Invalid resource attribute (empty key): ={s}", .{value});
             continue;
         }
 
         // Skip service.name if OTEL_SERVICE_NAME is set (it takes precedence)
-        if (skip_service_name and std.mem.eql(u8, key_part, "service.name")) {
+        if (skip_service_name and std.mem.eql(u8, entry.name, "service.name")) {
             continue;
         }
 
-        const key = try allocator.dupe(u8, key_part);
-        errdefer allocator.free(key);
-
-        const value = try allocator.dupe(u8, value_part);
-        errdefer allocator.free(value);
-
-        try attributes.append(allocator, Attribute{
-            .key = key,
-            .value = AttributeValue{ .string = value },
-        });
+        try attributes.append(allocator, try Attribute.dupe(allocator, .{
+            .key = entry.name,
+            .value = .{ .string = value },
+        }));
     }
 }
 


### PR DESCRIPTION
There is a recurring need to parse strings of the form `foo=1,bar=2`, so I made an iterator to centralize the parsing logic and separate it from the unrelated logic of using the parsed strings.